### PR TITLE
fix: store CF7 file uploads under original input name

### DIFF
--- a/includes/formhelpers/class-checkview-cf7-helper.php
+++ b/includes/formhelpers/class-checkview-cf7-helper.php
@@ -211,7 +211,11 @@ if ( ! class_exists( 'Checkview_Cf7_Helper' ) ) {
 					if ( in_array( $key, $uploaded_files ) ) {
 						$file = is_array( $files[ $key ] ) ? reset( $files[ $key ] ) : $files[ $key ];
 						$file_name = empty( $file ) ? '' : $time_now . '-' . $key . '-' . basename( $file );
+						// Store under suffixed key for backward compat (no current readers, but preserved).
 						$form_data[ $key . 'cv_cf7_file' ] = $file_name;
+						// Also store under original field name so CheckView SaaS validation
+						// (which looks up by input name/id) can find the uploaded file.
+						$form_data[ $key ] = $file_name;
 					}
 				}
 


### PR DESCRIPTION
## Summary
- CF7 helper now stores file uploads under both the original input name AND the legacy `{name}cv_cf7_file` suffixed key.
- Previously only the suffixed key was used; CheckView SaaS validation looks up by input name and never found CF7 files → `assert_form_submitted` silently passed even when uploads failed.

Pairs with SaaS PR https://github.com/CheckView/checkview/pull/new/feat/upload-file-step-generation which generates the upload_file steps that exercise this fix.

## Test plan
- [ ] Install plugin on InstaWP CF7 test site
- [ ] Run a CheckView CF7 flow with a file field after the SaaS PR ships to test
- [ ] Confirm `wp_cv_entry_meta` contains 2 rows per file field (`{name}` + `{name}cv_cf7_file`) with matching values
- [ ] Confirm `assert_form_submitted` passes when file is uploaded
- [ ] Confirm validation correctly fails if file is required but not uploaded (instead of silently passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)