### PR TITLE
fix: preserve native Fluent Forms email feed under disable_actions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -209,6 +209,8 @@ Support and test configuration are handled through the CheckView platform. Pleas
 * Fix form page dropdown returning Kadence Element (popup/hook) container URLs instead of real display URLs.
 * Add `kadence_element` post type to the form-host page exclusion list across all supported form plugins, reusable block recursion, and the WPForms location-meta lookup.
 * Properly disable non-essential Ninja Forms actions during CheckView tests.
+* Fix Fluent Forms disable_actions handler stripping the native email feed alongside third-party integrations during CheckView tests, causing `assert_email_received` to time out.
+* Fluent Forms disable_actions handler now preserves the native `notifications` feed key while still suppressing third-party feeds (slack, mailchimp, webhook, zapier, etc.).
 
 = 2.0.32 =
 * Fix WP Forms simple name fields.
@@ -569,6 +571,8 @@ Support and test configuration are handled through the CheckView platform. Pleas
 
 = 2.0.33 =
 * Properly disable non-essential Ninja Forms actions during CheckView tests.
+* Fix Fluent Forms disable_actions handler stripping the native email feed alongside third-party integrations during CheckView tests, causing `assert_email_received` to time out.
+* Fluent Forms disable_actions handler now preserves the native `notifications` feed key while still suppressing third-party feeds (slack, mailchimp, webhook, zapier, etc.).
 
 = 2.0.32 =
 * Fix WP Forms simple name fields.

--- a/includes/formhelpers/class-checkview-fluent-forms-helper.php
+++ b/includes/formhelpers/class-checkview-fluent-forms-helper.php
@@ -149,7 +149,7 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 			add_filter(
 				'fluentform/global_notification_active_types',
 				array( $this, 'checkview_disable_form_actions' ),
-				99,
+				PHP_INT_MAX,
 				2,
 			);
 
@@ -369,10 +369,28 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 		 */
 		public function checkview_disable_form_actions( $notifications, $form_id ) {
 			$cv_test_id = get_checkview_test_id();
-			if ( $cv_test_id && 'true' == get_option( 'disable_actions_' . $cv_test_id, false ) ) {
-				return array();
+			if ( ! $cv_test_id || 'true' !== get_option( 'disable_actions_' . $cv_test_id, false ) ) {
+				return $notifications;
 			}
-			return $notifications;
+			if ( ! is_array( $notifications ) || empty( $notifications ) ) {
+				return $notifications;
+			}
+			// Preserve native Fluent Forms feeds only; drop third-party integrations
+			// (slack, mailchimp_feeds, webhook, zapier, hubspot, pipedrive, etc.) during
+			// CheckView automated tests so assert_email_received still receives the
+			// confirmation mail to <test_run_id>@test-mail.checkview.io.
+			//
+			// Native key list verified against Fluent Forms 6.2.2 upstream source —
+			// EmailNotificationActions.php registers $types['notifications'] (the email
+			// feed). If a future Fluent version RENAMES this key, assert_email_received
+			// will time out on the next run, prompting an update here. If Fluent ADDS a
+			// new native non-email key (e.g. a hypothetical 'auto_responder' feed), it
+			// will be silently filtered out — acceptable in the test context since the
+			// email feed still fires. Visible failure on rename is preferred over a
+			// silent fallback to "all feeds fire" which would let real integrations run
+			// during automated tests.
+			$native_keys = array( 'notifications' );
+			return array_intersect_key( $notifications, array_flip( $native_keys ) );
 		}
 
 		/**

--- a/tests/test-ff.php
+++ b/tests/test-ff.php
@@ -69,4 +69,83 @@ class Test_Checkview_Fluent_Forms_Helper extends WP_UnitTestCase {
 	public function test_actions() {
 		$this->assertTrue( has_action( 'fluentform_submission_inserted' ) );
 	}
+
+	public function test_disable_form_actions_no_test_id_returns_unchanged() {
+		$input  = array( 'notifications' => 'email_notifications', 'slack' => 'slack' );
+		$result = $this->helper->checkview_disable_form_actions( $input, 1 );
+		$this->assertSame( $input, $result );
+	}
+
+	public function test_disable_form_actions_strips_integrations_preserves_native_email() {
+		$test_id = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$input = array(
+			'notifications'   => 'email_notifications',
+			'slack'           => 'slack',
+			'mailchimp_feeds' => 'mailchimp',
+			'webhook'         => 'webhook',
+		);
+
+		$result = $this->helper->checkview_disable_form_actions( $input, 1 );
+		$this->assertSame( array( 'notifications' => 'email_notifications' ), $result );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_form_actions_integration_only_returns_empty() {
+		$test_id = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$input  = array( 'slack' => 'slack', 'webhook' => 'webhook' );
+		$result = $this->helper->checkview_disable_form_actions( $input, 1 );
+		$this->assertSame( array(), $result );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_form_actions_empty_array_returns_empty() {
+		$test_id = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$result = $this->helper->checkview_disable_form_actions( array(), 1 );
+		$this->assertSame( array(), $result );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_form_actions_null_input_returns_unchanged() {
+		$test_id = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$result = $this->helper->checkview_disable_form_actions( null, 1 );
+		$this->assertNull( $result );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_form_actions_non_array_input_returns_unchanged() {
+		$test_id = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$result = $this->helper->checkview_disable_form_actions( 'unexpected_string', 1 );
+		$this->assertSame( 'unexpected_string', $result );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
 }


### PR DESCRIPTION
## Summary

- Fixes Fluent Forms `disable_actions` handler over-blocking native email notifications
- v2.0.31 changed the handler to `return array()`, which strips ALL feed types from `fluentform/global_notification_active_types` including the native `notifications` (email) feed
- Result: CheckView automated tests on Fluent Forms forms submit successfully but `assert_email_received` times out because no confirmation email is sent
- Switch to a native-key allowlist via `array_intersect_key` — preserves only `notifications` (email feed); third-party integration feeds (slack, mailchimp, webhook, zapier, hubspot, pipedrive, etc.) continue to be suppressed during tests
- Bump filter priority `99` → `PHP_INT_MAX` so any late-loading Pro integration that re-adds itself can't slip past our handler
- Tighten option comparison `==` → `!==`, add `is_array` / `empty` input guards

## Empirical evidence (collected on `intricate-jellyfish-a6a93b.instawp.xyz` 2026-04-29)

- Pre-2.0.31 helper, `disable_actions=true`, Fluent Forms test: ✅ email arrives (handler returned malformed value, Fluent ignored override)
- 2.0.31+ helper, `disable_actions=true`, Fluent Forms test: ❌ email never arrives (failing run IDs: `d27d0f54`, `8565ba01`, `d1cb6b00`, `dab56caf`)
- 2.0.31+ helper, `disable_actions=false` toggled at flow level: ✅ email arrives
- HAR confirms form submit returns `success:true, insert_id:N+, error:""` — submission persists fine; the break is post-submit on the notification feed

## Native key list

Verified against Fluent Forms 6.2.2 source: `app/Services/FormBuilder/Notifications/EmailNotificationActions.php:27-29` registers `$types['notifications'] = 'email_notifications'`. This is the only native key. Third-party integrations register additional keys (mailchimp_feeds, slack, webhook, zapier, etc.).

If a future Fluent version renames `notifications`, `assert_email_received` will fail visibly on the next test run, prompting an update here. Visible failure on rename is preferred over a silent fallback.

## Test plan

- [ ] Build new helper plugin zip from this branch
- [ ] Upload + activate on `intricate-jellyfish-a6a93b.instawp.xyz`
- [ ] Trigger CheckView SaaS test runs against test flows `16ebea7c-731c-4b37-b85a-be034ca1f62f` (Fluent button) and `b2d1153c-933f-461e-a191-a9f4b26fe003` (Fluent dropzone) — expect both PASSED with `assert_email_received` PASSED
- [ ] Confirm via Postmark API: `TotalCount: 1` for `<run_id>@test-mail.checkview.io`
- [ ] Negative control: add a webhook integration feed pointing to `https://httpbin.org/post`, run again, confirm form submits + email arrives + the webhook does NOT fire (third-party integration still suppressed during test)
- [ ] Pre-flight smoke: trigger a Fluent run with `disable_actions=false` toggled at flow level — should still pass (early-return path unchanged)
- [ ] PHPUnit: 6 new test cases added in `tests/test-ff.php` for `checkview_disable_form_actions` (no test ID → unchanged; native+integration mix → only native; integration-only → empty; empty input → empty; null → null; non-array → unchanged)

## Sibling helper audit (no changes needed)

All 7 other plugins with `disable_actions` handlers verified correctly preserving native email:
- Ninja Forms: line 300, allowlists `email`/`successmessage`/`save`
- WPForms: `checkview-helper-functions.php` global filters strip provider list, preserve SMTP infra; native email runs through `wpforms_process_complete` separately
- Gravity Forms: `gform_addon_pre_process_feeds` only affects add-on feeds, native uses `gform_after_submission`
- Formidable: allowlists `email`/`register`/`on_submit` via `frm_custom_trigger_action`
- Forminator: `forminator_is_addons_feature_enabled` only gates `init_addons()`, native unaffected
- WS Forms: allowlists `database`/`message`/`email` via `wsf_action_post_do`
- Everest Forms: `remove_all_actions` on Zapier-specific hooks, native email filter at priority 99 runs first

CF7 has no analogous handler — architecturally lacks a central registry to filter (popular CF7 integration plugins hook `wpcf7_mail_sent` directly, no per-plugin suppression possible without enumeration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)