### PR TITLE
fix: defer GF entry deletion to allow async feed processing

### DIFF
--- a/includes/checkview-functions.php
+++ b/includes/checkview-functions.php
@@ -1112,6 +1112,55 @@ if ( ! function_exists( 'checkview_delete_tables_data' ) ) {
 	// Attach the function to the cron event.
 	add_action( 'checkview_delete_table_cron_hook', 'checkview_delete_tables_data' );
 }
+
+if ( ! function_exists( 'checkview_gf_should_defer_delete' ) ) {
+	/**
+	 * Whether to defer GF entry deletion via cron. Defaults to true (the fix).
+	 *
+	 * Customers can opt out via `define( 'CHECKVIEW_GF_DEFER_ENTRY_DELETE', false );`
+	 * in wp-config.php as an emergency rollback to legacy synchronous deletion.
+	 *
+	 * @return bool
+	 */
+	function checkview_gf_should_defer_delete() {
+		if ( defined( 'CHECKVIEW_GF_DEFER_ENTRY_DELETE' ) && false === CHECKVIEW_GF_DEFER_ENTRY_DELETE ) {
+			return false;
+		}
+		return true;
+	}
+}
+
+if ( ! function_exists( 'checkview_gf_run_deferred_entry_delete' ) ) {
+	/**
+	 * Cron handler: deletes a GF entry deferred from form submission.
+	 *
+	 * The deletion is deferred so GF async feed processing (GF_Background_Process)
+	 * has time to load the entry and fire third-party integrations. Without this
+	 * delay, GF_Feed_Processor::task() aborts with "entry not found".
+	 *
+	 * @param int $entry_id GF entry ID.
+	 * @return void
+	 */
+	function checkview_gf_run_deferred_entry_delete( $entry_id ) {
+		if ( ! class_exists( 'GFAPI' ) ) {
+			return; // Gravity Forms not active anymore — nothing to delete.
+		}
+		$result = GFAPI::delete_entry( (int) $entry_id );
+		// Log only real failures. Skip 'invalid_entry_id' — that's the expected
+		// case when the entry was already cleaned up (admin manual delete, etc.)
+		// and would otherwise spam ip-logs (logs file grows unbounded).
+		if ( is_wp_error( $result )
+			&& 'invalid_entry_id' !== $result->get_error_code()
+			&& class_exists( 'Checkview_Admin_Logs' ) ) {
+			Checkview_Admin_Logs::add(
+				'ip-logs',
+				'GF deferred entry delete failed for entry [' . (int) $entry_id . ']: ' . $result->get_error_message()
+			);
+		}
+	}
+	add_action( 'checkview_gf_deferred_entry_delete', 'checkview_gf_run_deferred_entry_delete' );
+}
+
 add_action(
 	'wp_ajax_checkview_get_status',
 	'checkview_get_option_data_handler'

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -224,12 +224,16 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		}
 
 		/**
-		 * Stores the test results and finishes the testing session.
+		 * Clones the GF submission to cv_entry tables, schedules deferred deletion
+		 * of the source GF entry, and finishes the testing session.
 		 *
-		 * Deletes test submission from Formidable database table.
+		 * Deletion is deferred ~15 min to allow GF async feed processing
+		 * (Mailchimp, Webhooks, etc.) to load the entry and fire third-party
+		 * integrations. See checkview_gf_should_defer_delete() for the
+		 * emergency-rollback escape hatch.
 		 *
 		 * @param array  $entry Form entry data.
-		 * @param object $form Form object.
+		 * @param object $form  Form object.
 		 * @return void
 		 */
 		public function checkview_clone_entry( $entry, $form ) {
@@ -243,7 +247,21 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 			self::checkview_clone_gf_entry( $entry['id'], $form_id, $checkview_test_id );
 
 			if ( isset( $entry['id'] ) ) {
-				GFAPI::delete_entry( $entry['id'] );
+				$entry_id = (int) $entry['id'];
+				if ( checkview_gf_should_defer_delete() ) {
+					// Defer entry deletion so GF async feed processing
+					// (GF_Background_Process) has time to load the entry and fire
+					// third-party integrations. Without this delay,
+					// GF_Feed_Processor::task() aborts with "entry not found".
+					wp_schedule_single_event(
+						time() + 15 * MINUTE_IN_SECONDS,
+						'checkview_gf_deferred_entry_delete',
+						array( $entry_id )
+					);
+				} else {
+					// Emergency-rollback escape hatch — legacy synchronous deletion.
+					GFAPI::delete_entry( $entry_id );
+				}
 			}
 
 			complete_checkview_test( $checkview_test_id );

--- a/tests/test-checkview-functions.php
+++ b/tests/test-checkview-functions.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Tests for global functions in includes/checkview-functions.php.
+ *
+ * This file is intentionally ungated (no is_plugin_active() check) so it runs
+ * on CI, where form plugins like Gravity Forms are not installed. Tests here
+ * should only exercise pure functions that don't require GF/etc. to be loaded.
+ */
+class TestCheckviewFunctions extends WP_UnitTestCase {
+
+	/**
+	 * Confirms the deferred-delete cron handler is registered with the
+	 * 'checkview_gf_deferred_entry_delete' action. This is the primary
+	 * regression guard for the GF async-feed fix; if a future refactor
+	 * accidentally removes the registration, this test catches it on CI.
+	 */
+	public function test_deferred_delete_handler_is_registered() {
+		$priority = has_action( 'checkview_gf_deferred_entry_delete', 'checkview_gf_run_deferred_entry_delete' );
+		$this->assertNotFalse( $priority, 'checkview_gf_run_deferred_entry_delete must be registered on checkview_gf_deferred_entry_delete.' );
+	}
+
+	/**
+	 * checkview_gf_should_defer_delete() defaults to true (the fix is enabled).
+	 * Constant-based opt-out is tested in tests/test-gf-legacy-mode.php, which
+	 * lives in a separate file because define() is irreversible per process.
+	 */
+	public function test_should_defer_delete_default_is_true() {
+		$this->assertTrue( checkview_gf_should_defer_delete() );
+	}
+}

--- a/tests/test-gf-legacy-mode.php
+++ b/tests/test-gf-legacy-mode.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Tests for the CHECKVIEW_GF_DEFER_ENTRY_DELETE escape hatch constant.
+ *
+ * This file is intentionally separate from tests/test-gf.php because define()
+ * is irreversible within a single PHP process, and the constant set in this
+ * file would pollute other tests that depend on the default (deferred) behavior.
+ *
+ * Filename ordering: tests/test-checkview-functions.php sorts before
+ * tests/test-gf-legacy-mode.php alphabetically, so the registration test in
+ * test-checkview-functions runs first when both run on CI — meaning the
+ * constant defined here cannot leak into the registration test.
+ *
+ * NO plugin gate — checkview_gf_should_defer_delete() is pure PHP (only checks
+ * a constant) and doesn't require Gravity Forms to be loaded. Test runs on CI
+ * for full coverage.
+ *
+ * If anyone adds a second test to this file later that depends on the constant
+ * being unset, they'll need @runInSeparateProcess + @preserveGlobalState
+ * disabled annotations on that test.
+ */
+class TestCheckviewGfLegacyMode extends WP_UnitTestCase {
+
+	/**
+	 * Defining CHECKVIEW_GF_DEFER_ENTRY_DELETE = false should opt out of the
+	 * deferred-delete fix and revert to legacy synchronous deletion behavior.
+	 */
+	public function test_should_defer_delete_respects_constant() {
+		// Default behavior (constant undefined) returns true.
+		if ( ! defined( 'CHECKVIEW_GF_DEFER_ENTRY_DELETE' ) ) {
+			$this->assertTrue( checkview_gf_should_defer_delete(), 'Default behavior should defer.' );
+		}
+
+		// Define the constant to opt out.
+		define( 'CHECKVIEW_GF_DEFER_ENTRY_DELETE', false );
+
+		$this->assertFalse(
+			checkview_gf_should_defer_delete(),
+			'CHECKVIEW_GF_DEFER_ENTRY_DELETE=false must disable deferred deletion (escape hatch).'
+		);
+	}
+}

--- a/tests/test-gf.php
+++ b/tests/test-gf.php
@@ -23,6 +23,12 @@ class Test_Checkview_Gforms_Helper extends WP_UnitTestCase {
 		$this->helper = new Checkview_Gforms_Helper();
 	}
 
+	public function tearDown(): void {
+		// Clean up any scheduled deferred-delete events from individual tests.
+		wp_clear_scheduled_hook( 'checkview_gf_deferred_entry_delete' );
+		parent::tearDown();
+	}
+
 	public function test_construct() {
 		$this->assertInstanceOf( 'Checkview_Gforms_Helper', $this->helper );
 	}
@@ -143,5 +149,124 @@ class Test_Checkview_Gforms_Helper extends WP_UnitTestCase {
 			$settings1,
 			$this->helper->checkview_disable_addons_feed( $feeds, $entry, $form )
 		);
+	}
+
+	/**
+	 * Asserts that checkview_clone_entry schedules the deferred-delete cron
+	 * event with the entry id as args, using a delay >= 15 minutes.
+	 *
+	 * Requires a real GF form + entry to exist; skipped if GFAPI is unavailable
+	 * (file-level gate) or if entry creation fails in the test fixture.
+	 */
+	public function test_clone_entry_schedules_deferred_delete() {
+		if ( ! class_exists( 'GFAPI' ) ) {
+			$this->markTestSkipped( 'GFAPI not available in test environment.' );
+		}
+
+		$form_id = GFAPI::add_form(
+			array(
+				'title'  => 'CV Test Form',
+				'fields' => array(),
+			)
+		);
+		if ( is_wp_error( $form_id ) ) {
+			$this->markTestSkipped( 'Could not add test form.' );
+		}
+
+		$entry_id = GFAPI::add_entry(
+			array(
+				'form_id' => $form_id,
+			)
+		);
+		if ( is_wp_error( $entry_id ) ) {
+			$this->markTestSkipped( 'Could not add test entry.' );
+		}
+
+		$entry = array( 'id' => (int) $entry_id, 'form_id' => $form_id );
+		$form  = array( 'id' => $form_id );
+
+		$_REQUEST['checkview_test_id'] = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+		$this->helper->checkview_clone_entry( $entry, $form );
+
+		$scheduled = wp_next_scheduled( 'checkview_gf_deferred_entry_delete', array( (int) $entry_id ) );
+		$this->assertNotFalse( $scheduled, 'Deferred-delete event should be scheduled.' );
+		$this->assertGreaterThanOrEqual( time() + ( 15 * MINUTE_IN_SECONDS ) - 60, $scheduled, 'Schedule should be at least ~15 min in the future.' );
+
+		// Cleanup.
+		unset( $_REQUEST['checkview_test_id'] );
+		GFAPI::delete_entry( $entry_id );
+		GFAPI::delete_form( $form_id );
+	}
+
+	/**
+	 * Asserts that checkview_clone_entry does NOT delete the entry synchronously.
+	 * Entry should still exist after clone_entry returns.
+	 */
+	public function test_clone_entry_does_not_delete_synchronously() {
+		if ( ! class_exists( 'GFAPI' ) ) {
+			$this->markTestSkipped( 'GFAPI not available in test environment.' );
+		}
+
+		$form_id = GFAPI::add_form(
+			array(
+				'title'  => 'CV Test Form 2',
+				'fields' => array(),
+			)
+		);
+		if ( is_wp_error( $form_id ) ) {
+			$this->markTestSkipped( 'Could not add test form.' );
+		}
+		$entry_id = GFAPI::add_entry( array( 'form_id' => $form_id ) );
+		if ( is_wp_error( $entry_id ) ) {
+			$this->markTestSkipped( 'Could not add test entry.' );
+		}
+
+		$entry = array( 'id' => (int) $entry_id, 'form_id' => $form_id );
+		$form  = array( 'id' => $form_id );
+
+		$_REQUEST['checkview_test_id'] = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+		$this->helper->checkview_clone_entry( $entry, $form );
+
+		$fetched = GFAPI::get_entry( $entry_id );
+		$this->assertFalse( is_wp_error( $fetched ), 'Entry should still exist after clone_entry (deletion deferred).' );
+
+		// Cleanup.
+		unset( $_REQUEST['checkview_test_id'] );
+		GFAPI::delete_entry( $entry_id );
+		GFAPI::delete_form( $form_id );
+	}
+
+	/**
+	 * Asserts that the deferred handler actually deletes the entry when run.
+	 */
+	public function test_deferred_handler_deletes_entry() {
+		if ( ! class_exists( 'GFAPI' ) ) {
+			$this->markTestSkipped( 'GFAPI not available in test environment.' );
+		}
+
+		$form_id = GFAPI::add_form(
+			array(
+				'title'  => 'CV Test Form 3',
+				'fields' => array(),
+			)
+		);
+		if ( is_wp_error( $form_id ) ) {
+			$this->markTestSkipped( 'Could not add test form.' );
+		}
+		$entry_id = GFAPI::add_entry( array( 'form_id' => $form_id ) );
+		if ( is_wp_error( $entry_id ) ) {
+			$this->markTestSkipped( 'Could not add test entry.' );
+		}
+
+		// Sanity: entry exists before handler runs.
+		$this->assertFalse( is_wp_error( GFAPI::get_entry( $entry_id ) ) );
+
+		// Invoke the handler directly.
+		checkview_gf_run_deferred_entry_delete( $entry_id );
+
+		// Entry should be gone.
+		$this->assertTrue( is_wp_error( GFAPI::get_entry( $entry_id ) ), 'Handler should have deleted the entry.' );
+
+		GFAPI::delete_form( $form_id );
 	}
 }


### PR DESCRIPTION
## Summary

Gravity Forms async feed integrations (Mailchimp, Webhooks, Zapier, etc.) have silently failed on CheckView automated tests since **2023-12-25** (commit `c32b9fc`). The helper deletes the GF entry synchronously in `gform_after_submission` priority 99, but GF's `GF_Background_Process` re-fetches the entry ~1 second later in a separate request and aborts with **"Entry not found"** — third-party feeds never fire.

This PR defers the deletion via `wp_schedule_single_event` by 15 min (matches the existing helper cron pattern at `checkview_rotate_user_credentials`).

**Confirmed via real logs** on `selective-yak-1838a1.instawp.xyz` test run `57e3130b-1f0b-481a-9ae4-41a48d3f9daf`:
```
17:56:22.896  Entry #889 created
17:56:22.897  Mailchimp + Webhooks feeds queued for ASYNC processing
              (helper plugin deletes entry #889 here)
17:56:23.607  ERROR: Aborting. Entry #889 not found for feed (#1 - Mailchimp Feed 1)
17:56:23.860  ERROR: same for Webhooks Feed 1
```

### Changes
- New `checkview_gf_should_defer_delete()` helper + `checkview_gf_run_deferred_entry_delete()` cron handler in `checkview-functions.php`. Registered outside `is_bot()` gate so cron fires reliably.
- Replace synchronous `GFAPI::delete_entry()` with conditional schedule in `class-checkview-gforms-helper.php`. Updated the misleading docblock that referenced Formidable.
- Emergency rollback: `define( 'CHECKVIEW_GF_DEFER_ENTRY_DELETE', false );` in `wp-config.php` reverts to legacy synchronous deletion.

### Why GF-specific
- **GF**: `GF_Background_Process::handle()` stores `[feed_id, entry_id]` then re-fetches the entry — fails when entry is gone. **CONFIRMED broken.**
- **WPForms**: Action Scheduler stores subscriber data **inline** in task args → resilient to entry deletion. Verified safe via real test on `cheapest-crayfish-8e1600.instawp.xyz`.
- **Formidable**: synchronous addons via `frm_after_create_entry` (Mailchimp at priority 10, helper deletion at 99 — Mailchimp fires *before* deletion). Verified safe via real test on `funny-hornet-6d37d6.instawp.xyz`.
- **CF7, NF, FF, WSF, Forminator, Everest**: synchronous addon processing — no async-feed framework, architecturally cannot trigger this bug.

## Test plan

- [ ] `composer test` passes (single-site + `WP_MULTISITE`)
- [ ] `composer phpcs` passes
- [ ] On `selective-yak-1838a1.instawp.xyz` (GF + Mailchimp + Pipedream-webhook + GF Logging enabled):
  - [ ] Confirm `wp cron event list` shows scheduled events (cron must be active)
  - [ ] Trigger flow `171ff8a1-6d52-4c14-898e-73f867ab8b40` via `mcp__checkview-test__checkview_run_test`
  - [ ] After ~30s: Mailchimp Audience shows new subscriber, Pipedream workflow shows new event
  - [ ] GF logs at `wp-content/uploads/gravity_forms/logs/gravityformsmailchimp_*.txt` show feed processed (no "Entry not found")
  - [ ] GF logs `gravityformswebhooks_*.txt` show successful HTTP delivery
  - [ ] After 16+ min: `wp_gf_entry` row gone (cron fired)
- [ ] Smoke check on WPForms / FF / NF flows for no regression
- [ ] Verify escape hatch: with `define('CHECKVIEW_GF_DEFER_ENTRY_DELETE', false)`, deletion reverts to synchronous and the original "Entry not found" bug returns (proves the toggle works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)