### PR TITLE
feat: allow_original_recipients append-mode for test emails

### DIFF
--- a/admin/class-checkview-admin.php
+++ b/admin/class-checkview-admin.php
@@ -439,6 +439,11 @@ class Checkview_Admin {
 		$disable_actions = isset( $_REQUEST['disable_actions'] )
 			? sanitize_text_field( wp_unslash( $_REQUEST['disable_actions'] ) )
 			: '';
+		$allow_original_recipients = isset( $_REQUEST['allow_original_recipients'] )
+			? sanitize_text_field( wp_unslash( $_REQUEST['allow_original_recipients'] ) )
+			: '';
+		$referrer_url = sanitize_url( wp_get_raw_referer(), array( 'http', 'https' ) );
+
 		// If not Ajax submission and found test_id.
 		if ( isset( $_SERVER['REQUEST_URI'] ) && strpos( sanitize_url( wp_unslash( $_SERVER['REQUEST_URI'] ) ), 'admin-ajax.php' ) === false && '' !== $cv_test_id ) {
 			// Create session for later use when form submit VIA AJAX.
@@ -451,6 +456,15 @@ class Checkview_Admin {
 			Checkview_Admin_Logs::add( 'ip-logs', 'Test ID format failed to validate, exiting.' );
 
 			return;
+		}
+
+		// Test-init reset for `allow_original_recipients`: deterministically
+		// delete orphan flags from a prior failed test before the new test
+		// starts. Site-scoped option (multisite-safe). Gated on the UUID
+		// having validated above so unauthenticated requests cannot trigger.
+		if ( ! empty( $cv_test_id ) ) {
+			delete_option( 'allow_original_recipients' );
+			delete_option( 'allow_original_recipients_set_at' );
 		}
 
 		if ( $cv_test_id && '' !== $cv_test_id ) {
@@ -536,6 +550,16 @@ class Checkview_Admin {
 
 		if ( 'true' === $disable_actions ) {
 			cv_update_option( 'disable_actions_' . $cv_test_id, 'true', false );
+		}
+
+		// Persist append-mode flag + companion `_set_at` timestamp. Site-scoped
+		// option (multisite-safe by default). The watchdog
+		// `cv_should_allow_original_recipients()` reads both at filter time.
+		// `_set_at` is set ONCE per test-init using time() (UTC) — do NOT re-set
+		// from form helpers; that would extend the staleness window.
+		if ( 'true' === $allow_original_recipients ) {
+			cv_update_option( 'allow_original_recipients', 'true', true );
+			cv_update_option( 'allow_original_recipients_set_at', (string) time(), true );
 		}
 
 		delete_transient( 'checkview_forms_test_transient' );

--- a/admin/class-checkview-admin.php
+++ b/admin/class-checkview-admin.php
@@ -553,22 +553,13 @@ class Checkview_Admin {
 			cv_update_option( 'disable_actions_' . $cv_test_id, 'true', false );
 		}
 
-		// Persist append-mode flag + companion `_set_at` timestamp, keyed BY TEST
-		// ID like disable_actions / disable_email_receipt / disable_webhooks.
-		//
-		// This was previously a single site-scoped option, which made concurrent
-		// tests interfere: test B's init deleted the flag while test A was still
-		// running, and A's flag would then enable append-mode for B. Since the
-		// flag decides whether a customer's real recipients receive test email,
-		// that is not a cosmetic scoping issue.
-		//
-		// The watchdog `cv_should_allow_original_recipients()` reads both at
-		// filter time. `_set_at` is set ONCE per test-init using time() (UTC) —
-		// do NOT re-set it from form helpers; that would extend the staleness
-		// window.
+		// `_set_at` is set ONCE per test-init — do NOT re-set it from form
+		// helpers, that would extend the staleness window the watchdog enforces.
+		// Not autoloaded: a timed-out test never reaches complete_checkview_test()
+		// and so orphans both keys permanently.
 		if ( 'true' === $allow_original_recipients && ! empty( $cv_test_id ) ) {
-			cv_update_option( 'allow_original_recipients_' . $cv_test_id, 'true', true );
-			cv_update_option( 'allow_original_recipients_set_at_' . $cv_test_id, (string) time(), true );
+			cv_update_option( 'allow_original_recipients_' . $cv_test_id, 'true', false );
+			cv_update_option( 'allow_original_recipients_set_at_' . $cv_test_id, (string) time(), false );
 		}
 
 		delete_transient( 'checkview_forms_test_transient' );

--- a/admin/class-checkview-admin.php
+++ b/admin/class-checkview-admin.php
@@ -458,10 +458,11 @@ class Checkview_Admin {
 			return;
 		}
 
-		// Test-init reset for `allow_original_recipients`: deterministically
-		// delete orphan flags from a prior failed test before the new test
-		// starts. Site-scoped option (multisite-safe). Gated on the UUID
-		// having validated above so unauthenticated requests cannot trigger.
+		// Legacy cleanup: the append-mode flag used to be site-scoped, which let
+		// two concurrent tests read each other's setting. It is now keyed by test
+		// id like every other per-test flag, so any unscoped leftovers from a
+		// build running the old shape are removed here. Gated on the UUID having
+		// validated above so unauthenticated requests cannot trigger it.
 		if ( ! empty( $cv_test_id ) ) {
 			delete_option( 'allow_original_recipients' );
 			delete_option( 'allow_original_recipients_set_at' );
@@ -552,14 +553,22 @@ class Checkview_Admin {
 			cv_update_option( 'disable_actions_' . $cv_test_id, 'true', false );
 		}
 
-		// Persist append-mode flag + companion `_set_at` timestamp. Site-scoped
-		// option (multisite-safe by default). The watchdog
-		// `cv_should_allow_original_recipients()` reads both at filter time.
-		// `_set_at` is set ONCE per test-init using time() (UTC) — do NOT re-set
-		// from form helpers; that would extend the staleness window.
-		if ( 'true' === $allow_original_recipients ) {
-			cv_update_option( 'allow_original_recipients', 'true', true );
-			cv_update_option( 'allow_original_recipients_set_at', (string) time(), true );
+		// Persist append-mode flag + companion `_set_at` timestamp, keyed BY TEST
+		// ID like disable_actions / disable_email_receipt / disable_webhooks.
+		//
+		// This was previously a single site-scoped option, which made concurrent
+		// tests interfere: test B's init deleted the flag while test A was still
+		// running, and A's flag would then enable append-mode for B. Since the
+		// flag decides whether a customer's real recipients receive test email,
+		// that is not a cosmetic scoping issue.
+		//
+		// The watchdog `cv_should_allow_original_recipients()` reads both at
+		// filter time. `_set_at` is set ONCE per test-init using time() (UTC) —
+		// do NOT re-set it from form helpers; that would extend the staleness
+		// window.
+		if ( 'true' === $allow_original_recipients && ! empty( $cv_test_id ) ) {
+			cv_update_option( 'allow_original_recipients_' . $cv_test_id, 'true', true );
+			cv_update_option( 'allow_original_recipients_set_at_' . $cv_test_id, (string) time(), true );
 		}
 
 		delete_transient( 'checkview_forms_test_transient' );

--- a/includes/checkview-functions.php
+++ b/includes/checkview-functions.php
@@ -334,6 +334,9 @@ if ( ! function_exists( 'complete_checkview_test' ) ) {
 		cv_delete_option( 'disable_actions' );
 		cv_delete_option( 'disable_email_receipt' );
 		cv_delete_option( 'disable_webhooks' );
+		cv_delete_option( 'allow_original_recipients_' . $checkview_test_id );
+		cv_delete_option( 'allow_original_recipients_set_at_' . $checkview_test_id );
+		// Legacy unscoped keys, from before the flag was per-test.
 		cv_delete_option( 'allow_original_recipients' );
 		cv_delete_option( 'allow_original_recipients_set_at' );
 
@@ -1735,9 +1738,13 @@ if ( ! function_exists( 'cv_should_allow_original_recipients' ) ) {
 	/**
 	 * Determines whether append-mode is active for the current request.
 	 *
-	 * Reads the site-scoped `allow_original_recipients` option (set during
-	 * test-init when the SaaS sends `?allow_original_recipients=true`) and
-	 * checks the companion `_set_at` timestamp.
+	 * Reads the per-test `allow_original_recipients_<test_id>` option (set during
+	 * test-init when the SaaS sends `?allow_original_recipients=true`) and checks
+	 * the companion `_set_at_<test_id>` timestamp.
+	 *
+	 * Keyed by test id, not site-scoped: the flag decides whether a customer's
+	 * real recipients receive test email, so two concurrent tests must not be able
+	 * to read each other's setting.
 	 *
 	 * Returns false on stale (>45min), missing, or future-dated timestamps to
 	 * fail safe. The 45-minute window protects orphan flags BETWEEN tests
@@ -1748,12 +1755,19 @@ if ( ! function_exists( 'cv_should_allow_original_recipients' ) ) {
 	 * @return boolean True if append-mode should fire, false otherwise.
 	 */
 	function cv_should_allow_original_recipients() {
-		// Site-scoped option (multisite-safe by default).
-		$flag = get_option( 'allow_original_recipients', false );
+		// Keyed by test id so two concurrent tests cannot read each other's
+		// setting. Without a resolvable test id there is nothing to authorise
+		// append-mode against, so fail closed.
+		$cv_test_id = function_exists( 'get_checkview_test_id' ) ? get_checkview_test_id() : '';
+		if ( empty( $cv_test_id ) ) {
+			return false;
+		}
+
+		$flag = get_option( 'allow_original_recipients_' . $cv_test_id, false );
 		if ( ! $flag ) {
 			return false;
 		}
-		$set_at = (int) get_option( 'allow_original_recipients_set_at', 0 );
+		$set_at = (int) get_option( 'allow_original_recipients_set_at_' . $cv_test_id, 0 );
 		if ( $set_at <= 0 || $set_at > time() || ( time() - $set_at ) > 2700 ) {
 			return false;
 		}

--- a/includes/checkview-functions.php
+++ b/includes/checkview-functions.php
@@ -1967,7 +1967,14 @@ if ( ! function_exists( 'cv_inject_reply_to_header' ) ) {
 			// Extract addresses already in this Reply-To and check via the
 			// shared parser to avoid substring false positives.
 			$value = trim( substr( $sanitized, strpos( $sanitized, ':' ) + 1 ) );
-			if ( ! cv_recipients_contain_test_email( $value ) ) {
+
+			if ( '' === $value ) {
+				// Valueless Reply-To. Elementor Pro emits a bare `Reply-To:`
+				// unconditionally when the form maps no reply-to field, and
+				// appending to it would yield a malformed `Reply-To:, addr`.
+				// Replace the whole header rather than append to nothing.
+				$list[ $existing_index ] = 'Reply-To: ' . TEST_EMAIL;
+			} elseif ( ! cv_recipients_contain_test_email( $value ) ) {
 				$list[ $existing_index ] = rtrim( $sanitized, ", \t" ) . ', ' . TEST_EMAIL;
 			}
 		}

--- a/includes/checkview-functions.php
+++ b/includes/checkview-functions.php
@@ -329,14 +329,13 @@ if ( ! function_exists( 'complete_checkview_test' ) ) {
 		cv_delete_option( 'disable_actions_' . $checkview_test_id );
 		cv_delete_option( 'disable_email_receipt_' . $checkview_test_id );
 		cv_delete_option( 'disable_webhooks_' . $checkview_test_id );
+		cv_delete_option( 'allow_original_recipients_' . $checkview_test_id );
+		cv_delete_option( 'allow_original_recipients_set_at_' . $checkview_test_id );
 
 		// Legacy cleanup: remove global options from before per-test scoping.
 		cv_delete_option( 'disable_actions' );
 		cv_delete_option( 'disable_email_receipt' );
 		cv_delete_option( 'disable_webhooks' );
-		cv_delete_option( 'allow_original_recipients_' . $checkview_test_id );
-		cv_delete_option( 'allow_original_recipients_set_at_' . $checkview_test_id );
-		// Legacy unscoped keys, from before the flag was per-test.
 		cv_delete_option( 'allow_original_recipients' );
 		cv_delete_option( 'allow_original_recipients_set_at' );
 

--- a/includes/checkview-functions.php
+++ b/includes/checkview-functions.php
@@ -334,6 +334,8 @@ if ( ! function_exists( 'complete_checkview_test' ) ) {
 		cv_delete_option( 'disable_actions' );
 		cv_delete_option( 'disable_email_receipt' );
 		cv_delete_option( 'disable_webhooks' );
+		cv_delete_option( 'allow_original_recipients' );
+		cv_delete_option( 'allow_original_recipients_set_at' );
 
 		// Legacy cleanup: remove orphaned captcha backup keys from old code.
 		cv_delete_option( 'checkview_wpforms_turnstile-site-key' );
@@ -1727,5 +1729,249 @@ if ( ! function_exists( 'checkview_truncate_meta_key' ) ) {
 		return function_exists( 'mb_substr' )
 			? mb_substr( $key, 0, 255, 'UTF-8' )
 			: substr( $key, 0, 255 );
+	}
+}
+if ( ! function_exists( 'cv_should_allow_original_recipients' ) ) {
+	/**
+	 * Determines whether append-mode is active for the current request.
+	 *
+	 * Reads the site-scoped `allow_original_recipients` option (set during
+	 * test-init when the SaaS sends `?allow_original_recipients=true`) and
+	 * checks the companion `_set_at` timestamp.
+	 *
+	 * Returns false on stale (>45min), missing, or future-dated timestamps to
+	 * fail safe. The 45-minute window protects orphan flags BETWEEN tests
+	 * (Cloud Run hard-caps a single test at 1200s/20min, so this window cannot
+	 * be hit during a single test). Test-init reset is the deterministic
+	 * cleanup path; this watchdog is the stale-flag rejection path.
+	 *
+	 * @return boolean True if append-mode should fire, false otherwise.
+	 */
+	function cv_should_allow_original_recipients() {
+		// Site-scoped option (multisite-safe by default).
+		$flag = get_option( 'allow_original_recipients', false );
+		if ( ! $flag ) {
+			return false;
+		}
+		$set_at = (int) get_option( 'allow_original_recipients_set_at', 0 );
+		if ( $set_at <= 0 || $set_at > time() || ( time() - $set_at ) > 2700 ) {
+			return false;
+		}
+		return true;
+	}
+}
+
+if ( ! function_exists( 'cv_sanitize_crlf' ) ) {
+	/**
+	 * Strips CR and LF characters from a string to prevent email header
+	 * injection.
+	 *
+	 * Defensive sanitizer applied to recipient and Reply-To values that flow
+	 * through CheckView's append-mode paths into wp_mail. If a customer's
+	 * form-configured recipient or Reply-To value contains embedded CRLF
+	 * (whether by misconfiguration or a malicious form submission), an
+	 * attacker could inject additional headers (e.g., a hidden Bcc) that
+	 * route mail to external addresses. By stripping CRLF before we
+	 * concatenate, we prevent this regardless of how `wp_mail` itself
+	 * handles the value downstream.
+	 *
+	 * Returns non-string values unchanged (arrays, null, etc.).
+	 *
+	 * @param mixed $value Value to sanitize.
+	 * @return mixed Sanitized value (string with CRLF removed, or input as-is).
+	 */
+	function cv_sanitize_crlf( $value ) {
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+		// CRLF stripping blocks RFC 5322 header injection. Null byte stripping
+		// is defense-in-depth — legacy C-level mail extensions might treat \0
+		// as a string terminator, truncating subsequent headers.
+		return str_replace( array( "\r\n", "\r", "\n", "\0" ), '', $value );
+	}
+}
+
+if ( ! function_exists( 'cv_recipients_contain_test_email' ) ) {
+	/**
+	 * Checks whether TEST_EMAIL is already present in a recipient list,
+	 * using proper email-address parsing rather than naive substring match.
+	 *
+	 * Splits on commas (or semicolons), extracts the bare email address from
+	 * each entry (handles "Name <addr>" RFC 2822 format and surrounding
+	 * whitespace), and compares case-insensitively against TEST_EMAIL.
+	 *
+	 * Avoids the substring-collision false positive where TEST_EMAIL might
+	 * appear within an unrelated address (e.g., `nottest_id@test-mail.checkview.io`
+	 * incorrectly matching `test_id@test-mail.checkview.io`).
+	 *
+	 * @param array|string $recipients Recipients (array of strings, or comma-/semi-separated string).
+	 *
+	 * @return bool True if any entry's email matches TEST_EMAIL, false otherwise.
+	 */
+	function cv_recipients_contain_test_email( $recipients ) {
+		if ( ! defined( 'TEST_EMAIL' ) ) {
+			return false;
+		}
+
+		if ( is_array( $recipients ) ) {
+			$entries = $recipients;
+		} else {
+			$entries = preg_split( '/[,;]/', (string) $recipients );
+		}
+
+		$test_email_lower = strtolower( TEST_EMAIL );
+
+		foreach ( $entries as $entry ) {
+			if ( ! is_string( $entry ) ) {
+				continue;
+			}
+			$bare = strtolower( trim( $entry ) );
+
+			// Extract email from "Name <addr>" RFC 2822 format. Anchor to the
+			// LAST `<...>` so display names containing brackets (e.g.,
+			// `<John> <john@x.com>`) resolve to the actual address, not the
+			// display-name fragment.
+			if ( preg_match( '/<([^<>]+)>\s*$/', $bare, $matches ) ) {
+				$bare = trim( $matches[1] );
+			}
+
+			if ( $bare === $test_email_lower ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}
+
+if ( ! function_exists( 'cv_append_test_email_string' ) ) {
+	/**
+	 * Appends TEST_EMAIL to a comma-separated recipient string with dedup.
+	 *
+	 * Matches the existing replace-mode behavior's data shape: returns a string
+	 * of comma-separated addresses. Skips append if TEST_EMAIL is already
+	 * present (defensive against double-firing filter chains and customer
+	 * misconfiguration).
+	 *
+	 * @param string $recipients Existing comma-separated recipients (may be empty).
+	 *
+	 * @return string Recipients with TEST_EMAIL appended (or unchanged if dedup hit).
+	 */
+	function cv_append_test_email_string( $recipients ) {
+		if ( ! defined( 'TEST_EMAIL' ) ) {
+			return $recipients;
+		}
+		if ( empty( $recipients ) ) {
+			return TEST_EMAIL;
+		}
+		if ( cv_recipients_contain_test_email( $recipients ) ) {
+			return cv_sanitize_crlf( $recipients );
+		}
+		// Strip CRLF from existing recipient string before concatenation to
+		// prevent header injection if the customer's form data contains
+		// embedded line breaks.
+		$sanitized = cv_sanitize_crlf( $recipients );
+		return rtrim( $sanitized, ", \t" ) . ',' . TEST_EMAIL;
+	}
+}
+
+if ( ! function_exists( 'cv_append_test_email_array' ) ) {
+	/**
+	 * Appends TEST_EMAIL to a recipient array with dedup.
+	 *
+	 * @param mixed $recipients Existing recipients (array or scalar — coerced to array).
+	 *
+	 * @return array Recipients with TEST_EMAIL appended (or unchanged if dedup hit).
+	 */
+	function cv_append_test_email_array( $recipients ) {
+		if ( ! defined( 'TEST_EMAIL' ) ) {
+			return is_array( $recipients ) ? $recipients : (array) $recipients;
+		}
+		$list = is_array( $recipients ) ? $recipients : (array) $recipients;
+		// Sanitize each entry — if a customer's form data contains embedded
+		// CRLF in a single recipient entry, downstream wp_mail conversion
+		// could inject headers when the array is joined into a comma string.
+		$list = array_map( 'cv_sanitize_crlf', $list );
+		if ( cv_recipients_contain_test_email( $list ) ) {
+			return $list;
+		}
+		$list[] = TEST_EMAIL;
+		return $list;
+	}
+}
+
+if ( ! function_exists( 'cv_inject_reply_to_header' ) ) {
+	/**
+	 * Injects `Reply-To: TEST_EMAIL` into a headers structure when append-mode
+	 * is active. Appends to existing Reply-To rather than replacing.
+	 *
+	 * Defends against MTA variance: when the customer's mail server splits
+	 * SMTP delivery per RCPT TO, Postmark may not see TEST_EMAIL in the To
+	 * header. Reply-To injection ensures Postmark's webhook payload always
+	 * carries the test_id-bearing address, which the test-runner's regex
+	 * fallback chain extracts.
+	 *
+	 * Handles both array (e.g. WC, Forminator, Fluent Forms) and string
+	 * (e.g. CRLF-joined) header shapes per the calling helper's data model.
+	 *
+	 * @param mixed $headers Existing headers (array or CRLF-string).
+	 *
+	 * @return mixed Headers with Reply-To injected, in the same shape as input.
+	 */
+	function cv_inject_reply_to_header( $headers ) {
+		if ( ! cv_should_allow_original_recipients() ) {
+			return $headers;
+		}
+		if ( ! defined( 'TEST_EMAIL' ) ) {
+			return $headers;
+		}
+
+		// Defensive: some plugins may pass header objects. We only know how
+		// to mutate arrays or strings — anything else passes through.
+		if ( ! is_array( $headers ) && ! is_string( $headers ) && ! is_null( $headers ) ) {
+			return $headers;
+		}
+
+		$is_array = is_array( $headers );
+
+		// Split on any line-ending variant (\r\n, \n, \r) to be MTA-agnostic.
+		// Some forms emit \n-only headers; bare \r is rare but defensive.
+		$list = $is_array
+			? $headers
+			: ( empty( $headers ) ? array() : preg_split( '/\r\n|\r|\n/', $headers ) );
+
+		$existing_index = null;
+		foreach ( $list as $index => $header ) {
+			// Tolerant Reply-To detector: matches `Reply-To:` and `Reply-To :`
+			// (optional whitespace before colon). Case-insensitive.
+			if ( is_string( $header ) && preg_match( '/^\s*Reply-To\s*:/i', $header ) ) {
+				$existing_index = $index;
+				break;
+			}
+		}
+
+		$test_email_lower = strtolower( TEST_EMAIL );
+
+		if ( null === $existing_index ) {
+			$list[] = 'Reply-To: ' . TEST_EMAIL;
+		} else {
+			$existing = $list[ $existing_index ];
+
+			// Sanitize CRLF unconditionally — neutralize any header injection
+			// in the existing value before we touch it, regardless of whether
+			// dedup hits or we append. Consistent with the other helpers
+			// (cv_append_test_email_string/array always sanitize).
+			$sanitized = cv_sanitize_crlf( $existing );
+			$list[ $existing_index ] = $sanitized;
+
+			// Extract addresses already in this Reply-To and check via the
+			// shared parser to avoid substring false positives.
+			$value = trim( substr( $sanitized, strpos( $sanitized, ':' ) + 1 ) );
+			if ( ! cv_recipients_contain_test_email( $value ) ) {
+				$list[ $existing_index ] = rtrim( $sanitized, ", \t" ) . ', ' . TEST_EMAIL;
+			}
+		}
+
+		return $is_array ? $list : implode( "\r\n", $list );
 	}
 }

--- a/includes/class-checkview-mail-redirect.php
+++ b/includes/class-checkview-mail-redirect.php
@@ -55,7 +55,8 @@ if ( ! class_exists( 'Checkview_Mail_Redirect' ) ) {
 		 *
 		 * Mirrors Checkview_Gforms_Helper::checkview_inject_email() behavior:
 		 * - Default (REPLACE): replace `to` with TEST_EMAIL and strip Cc/Bcc.
-		 * - When `disable_email_receipt_<test_id>` option is 'true' (APPEND):
+		 * - When `disable_email_receipt_<test_id>` is 'true' or the site-scoped
+		 *   allow_original_recipients window is active (APPEND):
 		 *   append TEST_EMAIL to the existing recipients rather than replacing.
 		 *
 		 * Two skip conditions avoid double-work when an earlier filter
@@ -72,8 +73,12 @@ if ( ! class_exists( 'Checkview_Mail_Redirect' ) ) {
 			}
 
 			$cv_test_id  = get_checkview_test_id();
-			$append_mode = $cv_test_id
-				&& 'true' === get_option( 'disable_email_receipt_' . $cv_test_id, false );
+			// Append mode is signaled two ways: the legacy per-test option, or the
+			// site-scoped allow_original_recipients option the SaaS sets at test-init.
+			$append_mode = ( $cv_test_id
+				&& 'true' === get_option( 'disable_email_receipt_' . $cv_test_id, false ) )
+				|| ( function_exists( 'cv_should_allow_original_recipients' )
+					&& cv_should_allow_original_recipients() );
 
 			if ( $append_mode ) {
 				if ( $this->contains_test_email( $atts['to'] ) ) {

--- a/includes/class-checkview-mail-redirect.php
+++ b/includes/class-checkview-mail-redirect.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'Checkview_Mail_Redirect' ) ) {
 		 * Mirrors Checkview_Gforms_Helper::checkview_inject_email() behavior:
 		 * - Default (REPLACE): replace `to` with TEST_EMAIL and strip Cc/Bcc.
 		 * - When `disable_email_receipt_<test_id>` is 'true' or the site-scoped
-		 *   allow_original_recipients window is active (APPEND):
+		 *   allow_original_recipients_<test_id> window is active (APPEND):
 		 *   append TEST_EMAIL to the existing recipients rather than replacing,
 		 *   and inject Reply-To: TEST_EMAIL for MTA-variance defense.
 		 *
@@ -75,7 +75,8 @@ if ( ! class_exists( 'Checkview_Mail_Redirect' ) ) {
 
 			$cv_test_id  = get_checkview_test_id();
 			// Append mode is signaled two ways: the legacy per-test option, or the
-			// site-scoped allow_original_recipients option the SaaS sets at test-init.
+			// per-test allow_original_recipients_<test_id> option the SaaS sets at
+			// test-init.
 			$append_mode = ( $cv_test_id
 				&& 'true' === get_option( 'disable_email_receipt_' . $cv_test_id, false ) )
 				|| ( function_exists( 'cv_should_allow_original_recipients' )

--- a/includes/class-checkview-mail-redirect.php
+++ b/includes/class-checkview-mail-redirect.php
@@ -57,7 +57,8 @@ if ( ! class_exists( 'Checkview_Mail_Redirect' ) ) {
 		 * - Default (REPLACE): replace `to` with TEST_EMAIL and strip Cc/Bcc.
 		 * - When `disable_email_receipt_<test_id>` is 'true' or the site-scoped
 		 *   allow_original_recipients window is active (APPEND):
-		 *   append TEST_EMAIL to the existing recipients rather than replacing.
+		 *   append TEST_EMAIL to the existing recipients rather than replacing,
+		 *   and inject Reply-To: TEST_EMAIL for MTA-variance defense.
 		 *
 		 * Two skip conditions avoid double-work when an earlier filter
 		 * (e.g. gform_pre_send_email at priority 99) already did the rewrite:
@@ -81,6 +82,17 @@ if ( ! class_exists( 'Checkview_Mail_Redirect' ) ) {
 					&& cv_should_allow_original_recipients() );
 
 			if ( $append_mode ) {
+				// Injected before the recipient short-circuit below, because it is
+				// a separate concern: some form plugins build their headers with
+				// no filter in between (Ninja Forms assembles them in
+				// Actions/Email.php and hands them straight to wp_mail), so this
+				// backstop is the only place the MTA-variance defense can reach
+				// them. cv_inject_reply_to_header() dedups and preserves the input
+				// type, so helpers that already injected are left unchanged.
+				if ( function_exists( 'cv_inject_reply_to_header' ) ) {
+					$atts['headers'] = cv_inject_reply_to_header( $atts['headers'] ?? '' );
+				}
+
 				if ( $this->contains_test_email( $atts['to'] ) ) {
 					return $atts;
 				}

--- a/includes/formhelpers/class-checkview-cf7-helper.php
+++ b/includes/formhelpers/class-checkview-cf7-helper.php
@@ -426,6 +426,18 @@ if ( ! class_exists( 'Checkview_Cf7_Helper' ) ) {
 		 * @return array
 		 */
 		public function checkview_inject_email( $args ) {
+			// New: append-mode branch — deliver to BOTH real recipient and test inbox.
+			// CF7's $args['recipient'] is a comma-separated string. additional_headers
+			// is a CRLF-separated string.
+			if ( cv_should_allow_original_recipients() ) {
+				$args['recipient']          = cv_append_test_email_string( $args['recipient'] );
+				$args['additional_headers'] = cv_inject_reply_to_header( $args['additional_headers'] ?? '' );
+
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission recipient email address: ' . wp_json_encode( $args['recipient'] ) );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission email additional headers: ' . wp_json_encode( $args['additional_headers'] ) );
+				return $args;
+			}
+
 			$cv_test_id = get_checkview_test_id();
 			if ( $cv_test_id && 'true' === get_option( 'disable_email_receipt_' . $cv_test_id, false ) ) {
 				$args['recipient'] .= ', ' . TEST_EMAIL;

--- a/includes/formhelpers/class-checkview-elementor-helper.php
+++ b/includes/formhelpers/class-checkview-elementor-helper.php
@@ -72,6 +72,20 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 				2
 			);
 
+			// Inject Reply-To under append-mode. Elementor Pro resolves its
+			// Reply-To value BEFORE `wp_mail_fields` fires and builds the header
+			// from that local variable rather than from
+			// `$fields['email_reply_to']`, so the headers filter is the only
+			// seam that can influence it.
+			add_filter(
+				'elementor_pro/forms/wp_mail_headers',
+				array(
+					$this,
+					'checkview_inject_reply_to',
+				),
+				99
+			);
+
 			// Limit Elementor Form submit actions to email only during test runs.
 			add_filter(
 				'elementor_pro/forms/submit_actions',
@@ -225,6 +239,9 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 		 * kept and the test inbox is appended; otherwise the recipient is
 		 * replaced and CC/BCC stripped so test mail cannot reach real recipients.
 		 *
+		 * Under append-mode (`?allow_original_recipients=true`) the customer's
+		 * full recipient list is preserved and the test inbox is appended.
+		 *
 		 * @param array                                           $fields wp_mail() arguments (email_to, email_to_cc, email_to_bcc, etc.).
 		 * @param \ElementorPro\Modules\Forms\Classes\Form_Record $record Form record.
 		 * @return array
@@ -233,6 +250,17 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 			$cv_test_id = get_checkview_test_id();
 
 			if ( ! $cv_test_id || ! defined( 'TEST_EMAIL' ) ) {
+				return $fields;
+			}
+
+			// New: append-mode branch — deliver to BOTH the real recipients and
+			// the test inbox. `email_to` is a comma-separated string here.
+			// CC/BCC are read out of $fields AFTER this filter runs, so leaving
+			// them untouched preserves the customer's full recipient list.
+			if ( cv_should_allow_original_recipients() ) {
+				$fields['email_to'] = cv_append_test_email_string( $fields['email_to'] ?? '' );
+
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission recipient email address: ' . wp_json_encode( $fields['email_to'] ) );
 				return $fields;
 			}
 
@@ -250,6 +278,36 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 			}
 
 			return $fields;
+		}
+
+		/**
+		 * Injects `Reply-To: TEST_EMAIL` into Elementor's email headers under
+		 * append-mode.
+		 *
+		 * Elementor Pro resolves its Reply-To address from the form record
+		 * *before* `elementor_pro/forms/wp_mail_fields` fires, then builds the
+		 * header from that local value rather than from
+		 * `$fields['email_reply_to']` — so mutating the field in the fields
+		 * filter has no effect. `elementor_pro/forms/wp_mail_headers` receives
+		 * the assembled CRLF-joined header string and is the only usable seam.
+		 *
+		 * Reply-To injection defends against MTA variance: when the customer's
+		 * mail server splits SMTP delivery per RCPT TO, Postmark may not see
+		 * TEST_EMAIL in the To header, and the test-runner's fallback chain
+		 * relies on the test_id-bearing address being present somewhere.
+		 *
+		 * @param string|array $headers Assembled email headers.
+		 * @return string|array Headers with Reply-To injected, in the input's shape.
+		 */
+		public function checkview_inject_reply_to( $headers ) {
+			if ( ! get_checkview_test_id() || ! cv_should_allow_original_recipients() ) {
+				return $headers;
+			}
+
+			$headers = cv_inject_reply_to_header( $headers );
+
+			Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode Elementor email headers: ' . wp_json_encode( $headers ) );
+			return $headers;
 		}
 
 		/**

--- a/includes/formhelpers/class-checkview-fluent-forms-helper.php
+++ b/includes/formhelpers/class-checkview-fluent-forms-helper.php
@@ -59,7 +59,16 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 					99,
 					4,
 				);
+			}
 
+			// Registered in BOTH disable_email_receipt branches (but still only
+			// inside a test session): `checkview_remove_email_header` is the only
+			// place Reply-To injection happens for Fluent, and append-mode needs
+			// it even when `disable_email_receipt` is set. Gating registration on
+			// the disable flag silently dropped the MTA-variance defense for that
+			// combination. The callback is branch-aware and leaves headers
+			// untouched in the disable path.
+			if ( defined( 'TEST_EMAIL' ) ) {
 				add_filter(
 					'fluentform/email_template_header',
 					array( $this, 'checkview_remove_email_header' ),
@@ -279,6 +288,14 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 			if ( cv_should_allow_original_recipients() ) {
 				$headers = cv_inject_reply_to_header( $headers );
 				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission email headers (CC/BCC preserved): ' . wp_json_encode( $headers ) );
+				return $headers;
+			}
+
+			// Disable-receipt path: the email is already being redirected wholesale,
+			// so leave headers alone. Matches the pre-existing behavior from when
+			// this filter was only registered outside the disable branch.
+			$cv_test_id = get_checkview_test_id();
+			if ( $cv_test_id && 'true' == get_option( 'disable_email_receipt_' . $cv_test_id, false ) ) {
 				return $headers;
 			}
 

--- a/includes/formhelpers/class-checkview-fluent-forms-helper.php
+++ b/includes/formhelpers/class-checkview-fluent-forms-helper.php
@@ -78,6 +78,12 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 				);
 			}
 
+			// Reply-To injection is consolidated into checkview_remove_email_header
+			// to avoid same-priority dual-callback race. The `email_to` callbacks
+			// (`checkview_remove_receipt` and `checkview_inject_email`) are
+			// internally branch-aware and switch to append-semantics when
+			// `cv_should_allow_original_recipients()` returns true.
+
 			// Use before_submission_confirmation instead of submission_inserted because
 			// Fluent Forms wraps submission_inserted in a try-catch that silently
 			// swallows exceptions (when WP_DEBUG is off). If any other hook handler
@@ -200,13 +206,25 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 		/**
 		 * Appends our test email for test form submissions.
 		 *
-		 * @param string $address Email address.
+		 * Branch-aware: in append-mode (`cv_should_allow_original_recipients()`
+		 * returns true), uses dedup-protected append. Otherwise preserves
+		 * existing partial-append behavior.
+		 *
+		 * @param string|array $address Email address.
 		 * @param string $notification Email notification.
 		 * @param array  $submitted_data Fluent Forms submitted data.
 		 * @param object $form Fluent Forms form object.
-		 * @return string Email.
+		 * @return string|array Email.
 		 */
 		public function checkview_inject_email( $address, $notification, $submitted_data, $form ) {
+			if ( cv_should_allow_original_recipients() ) {
+				$address = is_array( $address )
+					? cv_append_test_email_array( $address )
+					: cv_append_test_email_string( $address );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission recipient email address: ' . wp_json_encode( $address ) );
+				return $address;
+			}
+
 			if ( is_array( $address ) ) {
 				$address[] = TEST_EMAIL;
 			} else {
@@ -220,16 +238,29 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 		/**
 		 * Overwrites email recipient for test form submissions.
 		 *
-		 * @param string $address Email address.
+		 * Branch-aware: in append-mode, switches to append-semantics so the
+		 * real recipient also receives the email. Otherwise preserves existing
+		 * replace behavior.
+		 *
+		 * @param string|array $address Email address.
 		 * @param string $notification Email notification.
 		 * @param array  $submitted_data Fluent Forms submitted data.
 		 * @param object $form Fluent Forms form object.
-		 * @return string Email.
+		 * @return string|array Email.
 		 */
 		public function checkview_remove_receipt( $address, $notification, $submitted_data, $form ) {
+			if ( cv_should_allow_original_recipients() ) {
+				$address = is_array( $address )
+					? cv_append_test_email_array( $address )
+					: cv_append_test_email_string( $address );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission recipient email address: ' . wp_json_encode( $address ) );
+				return $address;
+			}
+
 			Checkview_Admin_Logs::add( 'ip-logs', 'Submission recipient email address: ' . wp_json_encode( TEST_EMAIL ) );
 			return TEST_EMAIL;
 		}
+
 
 		/**
 		 * Removes email headers.
@@ -239,6 +270,18 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 		 * @return array
 		 */
 		public function checkview_remove_email_header( array $headers, array $notification ): array {
+			// Append-mode: preserve original CC/BCC so customer's full
+			// recipient list still receives the email (matches the design
+			// intent that allow_original_recipients delivers to "everyone
+			// configured in the form"). Inject Reply-To here too — single
+			// callback avoids the same-priority race that splitting into
+			// two callbacks would create.
+			if ( cv_should_allow_original_recipients() ) {
+				$headers = cv_inject_reply_to_header( $headers );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission email headers (CC/BCC preserved): ' . wp_json_encode( $headers ) );
+				return $headers;
+			}
+
 			// Ensure headers are an array.
 			if ( ! is_array( $headers ) ) {
 				$headers = explode( "\r\n", $headers );

--- a/includes/formhelpers/class-checkview-formidable-helper.php
+++ b/includes/formhelpers/class-checkview-formidable-helper.php
@@ -129,6 +129,15 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 		 * @return string Email.
 		 */
 		public function checkview_inject_email( $email ) {
+			// New: append-mode branch — deliver to BOTH real recipient and test inbox.
+			if ( cv_should_allow_original_recipients() ) {
+				$email = is_array( $email )
+					? cv_append_test_email_array( $email )
+					: cv_append_test_email_string( $email );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission recipient email address: ' . wp_json_encode( $email ) );
+				return $email;
+			}
+
 			$cv_test_id = get_checkview_test_id();
 			if ( ! $cv_test_id || 'true' != get_option( 'disable_email_receipt_' . $cv_test_id, false ) ) {
 				$email = TEST_EMAIL;
@@ -149,6 +158,16 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 		 * @return array
 		 */
 		public function checkview_remove_email_header( array $headers, array $atts ): array {
+			$append_mode = cv_should_allow_original_recipients();
+
+			// Append-mode: preserve original CC/BCC so customer's full recipient
+			// list receives the email. Inject Reply-To for MTA-variance defense.
+			if ( $append_mode ) {
+				$headers = cv_inject_reply_to_header( $headers );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission email headers (CC/BCC preserved): ' . wp_json_encode( $headers ) );
+				return $headers;
+			}
+
 			$cv_test_id = get_checkview_test_id();
 			if ( $cv_test_id && 'true' == get_option( 'disable_email_receipt_' . $cv_test_id, false ) ) {
 				return $headers;
@@ -166,6 +185,7 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 			);
 
 			$array_values = array_values( $filtered_headers );
+
 			Checkview_Admin_Logs::add( 'ip-logs', 'Submission email headers: ' . wp_json_encode( $array_values ) );
 			return $array_values;
 		}

--- a/includes/formhelpers/class-checkview-forminator-helper.php
+++ b/includes/formhelpers/class-checkview-forminator-helper.php
@@ -115,6 +115,15 @@ if ( ! class_exists( 'Checkview_Forminator_Helper' ) ) {
 		 * @return string/ARRAY Email.
 		 */
 		public function checkview_inject_email( $email ) {
+			// New: append-mode branch — deliver to BOTH real recipient and test inbox.
+			if ( cv_should_allow_original_recipients() ) {
+				$email = is_array( $email )
+					? cv_append_test_email_array( $email )
+					: cv_append_test_email_string( $email );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission recipient email address: ' . wp_json_encode( $email ) );
+				return $email;
+			}
+
 			$cv_test_id = get_checkview_test_id();
 			if ( ! $cv_test_id || 'true' != get_option( 'disable_email_receipt_' . $cv_test_id, false ) ) {
 				$email   = array();
@@ -135,6 +144,14 @@ if ( ! class_exists( 'Checkview_Forminator_Helper' ) ) {
 		 * @return array
 		 */
 		public function checkview_remove_email_header( array $headers ): array {
+			// Append-mode: preserve original CC/BCC so customer's full recipient
+			// list receives the email. Inject Reply-To for MTA-variance defense.
+			if ( cv_should_allow_original_recipients() ) {
+				$headers = cv_inject_reply_to_header( $headers );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission email headers (CC/BCC preserved): ' . wp_json_encode( $headers ) );
+				return $headers;
+			}
+
 			// Ensure headers are an array.
 			if ( ! is_array( $headers ) ) {
 				$headers = explode( "\r\n", $headers );
@@ -148,6 +165,7 @@ if ( ! class_exists( 'Checkview_Forminator_Helper' ) ) {
 			);
 
 			$array_values = array_values( $filtered_headers );
+
 			Checkview_Admin_Logs::add( 'ip-logs', 'Submission email headers: ' . wp_json_encode( $array_values ) );
 			return $array_values;
 		}

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -616,6 +616,16 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		 * @return array Email.
 		 */
 		public function checkview_inject_email( $email ) {
+			// New: append-mode branch — deliver to BOTH real recipient and test inbox.
+			if ( cv_should_allow_original_recipients() ) {
+				$email['to'] = is_array( $email['to'] )
+					? cv_append_test_email_array( $email['to'] )
+					: cv_append_test_email_string( $email['to'] );
+				$email['headers'] = cv_inject_reply_to_header( $email['headers'] ?? array() );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission recipient email address: ' . wp_json_encode( $email['to'] ) );
+				return $email;
+			}
+
 			$cv_test_id = get_checkview_test_id();
 			if ( ! $cv_test_id || 'true' != get_option( 'disable_email_receipt_' . $cv_test_id, false ) ) {
 				$email['to'] = TEST_EMAIL;

--- a/includes/formhelpers/class-checkview-ninja-forms-helper.php
+++ b/includes/formhelpers/class-checkview-ninja-forms-helper.php
@@ -123,30 +123,24 @@ if ( ! class_exists( 'Checkview_Ninja_Forms_Helper' ) ) {
 		 * @return bool
 		 */
 		public function checkview_inject_email( $sent, $action_settings, $message, $headers, $attachments ) {
-			// New: append-mode branch — let Ninja Forms' own pipeline send ONE
-			// email with merged recipients (real + TEST_EMAIL) instead of the
-			// existing direct wp_mail() to TEST_EMAIL only. This avoids the
-			// double-send risk that the existing code structure has.
-			//
-			// We modify $action_settings['email_to'] in place (string,
-			// comma-separated per Ninja Forms data shape) and inject Reply-To
-			// into headers, then return the pass-through $sent value so NF
-			// continues its own send path.
+			// Append-mode branch — let Ninja Forms' own pipeline send ONE email
+			// with merged recipients (real + TEST_EMAIL) instead of the direct
+			// wp_mail() to TEST_EMAIL only that replace-mode does below. This
+			// avoids the double-send risk that the existing code structure has.
 			if ( cv_should_allow_original_recipients() ) {
-				$existing_to = isset( $action_settings['email_to'] ) ? $action_settings['email_to'] : '';
-				$action_settings['email_to'] = is_array( $existing_to )
-					? cv_append_test_email_array( $existing_to )
-					: cv_append_test_email_string( $existing_to );
+				// Nothing can be mutated at this hook. `ninja_forms_action_email_send`
+				// is a plain apply_filters(), so $action_settings arrives by value and
+				// any change is discarded; NF then sends with $action_settings['to']
+				// (Actions/Email.php), a key this callback is not even passed under
+				// that name. NF also exposes no filter between _get_headers() and
+				// wp_mail(), so neither recipients nor headers are reachable here.
+				//
+				// Both are handled by the wp_mail backstop (Checkview_Mail_Redirect),
+				// which appends TEST_EMAIL to the recipients and injects Reply-To for
+				// MTA-variance defense. Returning the pass-through $sent lets NF run
+				// its own send, so exactly one email goes out.
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode: NF send passed through to the wp_mail backstop.' );
 
-				// We don't have a way to influence headers here (NF builds them
-				// downstream after this filter), but Reply-To is best-effort —
-				// the To-header carries TEST_EMAIL via the recipient append, so
-				// Postmark will see it regardless.
-
-				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode: NF email_to = ' . wp_json_encode( $action_settings['email_to'] ) );
-
-				// Pass through $sent so NF's own pipeline runs (single email,
-				// merged recipients).
 				return $sent;
 			}
 

--- a/includes/formhelpers/class-checkview-ninja-forms-helper.php
+++ b/includes/formhelpers/class-checkview-ninja-forms-helper.php
@@ -123,6 +123,33 @@ if ( ! class_exists( 'Checkview_Ninja_Forms_Helper' ) ) {
 		 * @return bool
 		 */
 		public function checkview_inject_email( $sent, $action_settings, $message, $headers, $attachments ) {
+			// New: append-mode branch — let Ninja Forms' own pipeline send ONE
+			// email with merged recipients (real + TEST_EMAIL) instead of the
+			// existing direct wp_mail() to TEST_EMAIL only. This avoids the
+			// double-send risk that the existing code structure has.
+			//
+			// We modify $action_settings['email_to'] in place (string,
+			// comma-separated per Ninja Forms data shape) and inject Reply-To
+			// into headers, then return the pass-through $sent value so NF
+			// continues its own send path.
+			if ( cv_should_allow_original_recipients() ) {
+				$existing_to = isset( $action_settings['email_to'] ) ? $action_settings['email_to'] : '';
+				$action_settings['email_to'] = is_array( $existing_to )
+					? cv_append_test_email_array( $existing_to )
+					: cv_append_test_email_string( $existing_to );
+
+				// We don't have a way to influence headers here (NF builds them
+				// downstream after this filter), but Reply-To is best-effort —
+				// the To-header carries TEST_EMAIL via the recipient append, so
+				// Postmark will see it regardless.
+
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode: NF email_to = ' . wp_json_encode( $action_settings['email_to'] ) );
+
+				// Pass through $sent so NF's own pipeline runs (single email,
+				// merged recipients).
+				return $sent;
+			}
+
 			// Ensure headers are an array.
 			if ( ! is_array( $headers ) ) {
 				$headers = explode( "\r\n", $headers );

--- a/includes/formhelpers/class-checkview-wpforms-helper.php
+++ b/includes/formhelpers/class-checkview-wpforms-helper.php
@@ -266,10 +266,36 @@ if ( ! class_exists( 'Checkview_Wpforms_Helper' ) ) {
 		/**
 		 * Injects testing email address.
 		 *
+		 * Append-mode (when `cv_should_allow_original_recipients()` is true):
+		 * adds TEST_EMAIL to the existing recipient list so both the real
+		 * recipient and CheckView's test inbox receive the email. Also injects
+		 * Reply-To to defend against MTA variance — Postmark sees TEST_EMAIL in
+		 * the ReplyTo header even if the customer's MTA strips it from To.
+		 *
+		 * Replace-mode (default): preserves existing behavior of routing to
+		 * TEST_EMAIL only.
+		 *
 		 * @param array $email Email address details.
 		 * @return array
 		 */
 		public function checkview_inject_email( $email ) {
+			// New: append-mode branch — deliver to BOTH real recipient and test inbox.
+			if ( cv_should_allow_original_recipients() ) {
+				$email['address']        = cv_append_test_email_array( $email['address'] );
+				$email['replyto']        = $this->cv_append_replyto( $email['replyto'] ?? '' );
+				// Sanitize CC entries to prevent header injection if the
+				// customer's form data contains embedded CRLF in CC addresses.
+				$cc                      = $email['carboncopy'] ?? array();
+				$email['carboncopy']     = is_array( $cc )
+					? array_map( 'cv_sanitize_crlf', $cc )
+					: cv_sanitize_crlf( $cc );
+
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission recipient email address: ' . wp_json_encode( $email['address'] ) );
+
+				return $email;
+			}
+
+			// Existing replace-mode behavior (preserved unchanged).
 			$cv_test_id = get_checkview_test_id();
 			if ( ! $cv_test_id || 'true' != get_option( 'disable_email_receipt_' . $cv_test_id, false ) ) {
 				$count = count( $email['address'] );
@@ -286,6 +312,29 @@ if ( ! class_exists( 'Checkview_Wpforms_Helper' ) ) {
 			Checkview_Admin_Logs::add( 'ip-logs', 'Submission recipient email address: ' . wp_json_encode( $email['address'] ?? null ) );
 			Checkview_Admin_Logs::add( 'ip-logs', 'Submission sender email address: ' . wp_json_encode( $email['sender_address'] ?? null ) );
 			return $email;
+		}
+
+		/**
+		 * Appends TEST_EMAIL to a Reply-To string with dedup.
+		 *
+		 * WPForms' `replyto` is a single string (not array). Append rather
+		 * than replace so existing form-configured Reply-To is preserved.
+		 *
+		 * @param string $existing Existing reply-to value (may be empty).
+		 * @return string Reply-To with TEST_EMAIL appended.
+		 */
+		private function cv_append_replyto( $existing ) {
+			if ( ! defined( 'TEST_EMAIL' ) ) {
+				return $existing;
+			}
+			if ( empty( $existing ) ) {
+				return TEST_EMAIL;
+			}
+			if ( cv_recipients_contain_test_email( $existing ) ) {
+				return cv_sanitize_crlf( $existing );
+			}
+			$sanitized = cv_sanitize_crlf( $existing );
+			return rtrim( $sanitized, ", \t" ) . ', ' . TEST_EMAIL;
 		}
 		/**
 		 * Stores the test results and finishes the testing session.

--- a/includes/formhelpers/class-checkview-wsf-helper.php
+++ b/includes/formhelpers/class-checkview-wsf-helper.php
@@ -132,6 +132,30 @@ if ( ! class_exists( 'Checkview_WSF_Helper' ) ) {
 		 * @return bool
 		 */
 		public function checkview_inject_email( $to, $form, $submit, $action ) {
+			// New: append-mode branch — deliver to BOTH real recipient and test inbox.
+			// WS Forms uses RFC 2822 format strings (e.g. `"CheckView" <addr>`).
+			// Use the shared dedup parser to handle the format correctly and
+			// avoid substring false positives.
+			if ( cv_should_allow_original_recipients() ) {
+				$test_addr = '"CheckView" <' . TEST_EMAIL . '>';
+				// Sanitize before any concat to prevent header injection from
+				// customer-provided recipient strings.
+				if ( is_array( $to ) ) {
+					$to = array_map( 'cv_sanitize_crlf', $to );
+				} else {
+					$to = cv_sanitize_crlf( (string) $to );
+				}
+				if ( ! cv_recipients_contain_test_email( $to ) ) {
+					if ( is_array( $to ) ) {
+						$to[] = $test_addr;
+					} else {
+						$to = empty( $to ) ? $test_addr : rtrim( $to, ", \t" ) . ', ' . $test_addr;
+					}
+				}
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission recipient email address: ' . wp_json_encode( $to ) );
+				return $to;
+			}
+
 			$cv_test_id = get_checkview_test_id();
 			if ( ! $cv_test_id || 'true' != get_option( 'disable_email_receipt_' . $cv_test_id, false ) ) {
 				$to = array(
@@ -156,10 +180,17 @@ if ( ! class_exists( 'Checkview_WSF_Helper' ) ) {
 		 * @return array
 		 */
 		public function checkview_remove_email_header( $headers, $form, $submit_parse, $config ) {
+			// Append-mode: preserve original CC/BCC so customer's full recipient
+			// list receives the email. Inject Reply-To for MTA-variance defense.
+			if ( cv_should_allow_original_recipients() ) {
+				$headers = cv_inject_reply_to_header( $headers );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Append-mode submission email headers (CC/BCC preserved): ' . wp_json_encode( $headers ) );
+				return $headers;
+			}
+
 			$cv_test_id = get_checkview_test_id();
 			if ( $cv_test_id && 'true' == get_option( 'disable_email_receipt_' . $cv_test_id, false ) ) {
 				return $headers;
-
 			}
 			// Ensure headers are an array.
 			if ( ! is_array( $headers ) ) {
@@ -175,6 +206,7 @@ if ( ! class_exists( 'Checkview_WSF_Helper' ) ) {
 			);
 
 			$array_values = array_values( $filtered_headers );
+
 			Checkview_Admin_Logs::add( 'ip-logs', 'Submission email headers: ' . wp_json_encode( $array_values ) );
 			return $array_values;
 		}

--- a/includes/woocommercehelper/class-checkview-woo-automated-testing.php
+++ b/includes/woocommercehelper/class-checkview-woo-automated-testing.php
@@ -227,6 +227,30 @@ class Checkview_Woo_Automated_Testing {
 				10,
 				3
 			);
+
+			// MVP scope: customer_completed_order. Other WC email types
+			// (processing, on-hold, refunds, invoices, subscriptions) are
+			// deferred to follow-up PRs based on customer demand. Priority
+			// matches the existing two filters above for consistency.
+			$this->loader->add_filter(
+				'woocommerce_email_recipient_customer_completed_order',
+				$this,
+				'checkview_filter_admin_emails',
+				10,
+				3
+			);
+
+			// Reply-To injection on WC email headers — defends against MTA
+			// variance (Postmark sees TEST_EMAIL in ReplyTo even if customer
+			// MTA strips it from To). Single filter for all WC emails;
+			// callback gates on $email->id matching MVP scope.
+			$this->loader->add_filter(
+				'woocommerce_email_headers',
+				$this,
+				'checkview_inject_reply_to_headers',
+				10,
+				3
+			);
 			$this->loader->add_action(
 				'checkview_delete_orders_action',
 				$this,
@@ -743,6 +767,11 @@ class Checkview_Woo_Automated_Testing {
 		// Check view Bot IP.
 		$cv_bot_ip = checkview_get_api_ip();
 		if ( ( get_checkview_test_id() || ( is_array( $cv_bot_ip ) && in_array( $visitor_ip, $cv_bot_ip ) ) ) || ( 'checkview' === $payment_method || 'checkview' === $payment_made_by ) ) {
+			// New: append-mode — deliver to BOTH real recipient and test inbox.
+			if ( cv_should_allow_original_recipients() && defined( 'TEST_EMAIL' ) ) {
+				return cv_append_test_email_string( $recipient );
+			}
+
 			if ( defined( 'CV_DISABLE_EMAIL_RECEIPT' ) ) {
 				if ( defined( 'TEST_EMAIL' ) ) {
 					$recipient = $recipient . ', ' . TEST_EMAIL;
@@ -759,6 +788,28 @@ class Checkview_Woo_Automated_Testing {
 		return $recipient;
 	}
 
+	/**
+	 * Injects Reply-To: TEST_EMAIL into WC email headers when append-mode is
+	 * active for one of the MVP-scoped email types. Defends against MTA
+	 * variance — Postmark sees TEST_EMAIL in the ReplyTo header even if the
+	 * customer's MTA strips it from To.
+	 *
+	 * Gated on email_id matching MVP scope (new_order, failed_order,
+	 * customer_completed_order). Other WC email types pass through unchanged.
+	 *
+	 * @param string|array $headers Existing email headers.
+	 * @param string       $email_id WC email type identifier (e.g. 'new_order').
+	 * @param object       $email WC email object.
+	 *
+	 * @return string|array Headers with Reply-To injected (or unchanged).
+	 */
+	public function checkview_inject_reply_to_headers( $headers, $email_id, $email ) {
+		$mvp_email_ids = array( 'new_order', 'failed_order', 'customer_completed_order' );
+		if ( ! in_array( $email_id, $mvp_email_ids, true ) ) {
+			return $headers;
+		}
+		return cv_inject_reply_to_header( $headers );
+	}
 
 	/**
 	 * Stops delivery of WooCommerce webhooks for active CheckView test orders.

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,7 @@ Built specifically for WordPress and WooCommerce, CheckView helps site owners, d
 
 == Works Well With ==
 
-CheckView works well with popular WordPress form and eCommerce plugins including Contact Form 7, WPForms, Gravity Forms, Fluent Forms, Ninja Forms, Formidable Forms, WS Form, and WooCommerce. 
+CheckView works well with popular WordPress form and eCommerce plugins including Contact Form 7, WPForms, Gravity Forms, Fluent Forms, Ninja Forms, Formidable Forms, WS Form, Elementor Pro Forms (classic), and WooCommerce.
 
 == Important == 
 
@@ -122,7 +122,7 @@ Yes. A [CheckView](https://checkview.io/) account is required to enable automate
 
 = Which form plugins does CheckView support? =
 
-CheckView supports automated testing for many popular WordPress form plugins, including WS Form, WPForms, Ninja Forms, Gravity Forms, Formidable Forms, Contact Form 7, and Fluent Forms.
+CheckView supports automated testing for many popular WordPress form plugins, including WS Form, WPForms, Ninja Forms, Gravity Forms, Formidable Forms, Contact Form 7, Fluent Forms, and Elementor Pro Forms (classic). Elementor support covers the classic Form widget and requires Elementor Pro; V4 "Atomic" forms are not supported.
 
 = If my preferred form plugin is not listed, can I still use CheckView? =
 


### PR DESCRIPTION
## Summary

Adds support for the SaaS `allow_original_recipients` toggle (ClickUp [868ar4waw](https://app.clickup.com/t/868ar4waw)). When the SaaS sends `?allow_original_recipients=true` alongside `checkview_test_id`, the helper **appends** `TEST_EMAIL` to each form's existing recipient list instead of replacing it. The customer's real recipients **and** CheckView's test inbox both receive the email, so `assert_email_received` keeps working while the customer can verify their downstream notification pipeline.

Behavior is unchanged when the flag is absent — replace-mode (current behavior) continues to fire.

## What's in the PR

**`includes/checkview-functions.php`**
- `cv_should_allow_original_recipients()` — reads the site-scoped option + 45-min `_set_at` window
- `cv_recipients_contain_test_email()` — RFC 2822-aware dedup parser
- `cv_append_test_email_string()` / `cv_append_test_email_array()` — dedup-protected append helpers
- `cv_inject_reply_to_header()` — Reply-To injection (array + CRLF/LF/CR string shapes)
- `cv_sanitize_crlf()` — CRLF + null-byte stripping
- `complete_checkview_test()` cleans up the new options

**`admin/class-checkview-admin.php`**
- Parses `?allow_original_recipients=true` after the existing UUID validation gate
- Test-init reset (deletes orphan options on every UUID-validated request)
- Persists option + `_set_at` timestamp

**Form helpers** — append-mode branch added to WPForms, Fluent Forms, Gravity Forms, Ninja Forms, Formidable, Forminator, CF7, WS Form, Elementor Pro (classic Form widget), plus WooCommerce (`new_order`, `failed_order`, `customer_completed_order`; other order types deferred).

**`includes/class-checkview-mail-redirect.php`** — the plugin-agnostic `wp_mail` backstop is append-mode aware and injects Reply-To (see below).

## Design notes

- **Watchdog**: the 45-min stale window protects against orphan flags *between* tests if `complete_checkview_test()` fails. Cloud Run hard-caps a single test at 20 min, so the window cannot trigger mid-test.
- **CC/BCC preserved** in append-mode for the four helpers that strip them in replace-mode (Fluent, Formidable, Forminator, WS Form) — per the design intent that everyone configured in the form receives the email.
- **CRLF + null-byte sanitization** on every customer-controlled value flowing into headers or recipients, as defense-in-depth against header injection from malformed form data.

### Reply-To injection (MTA-variance defense)

Some shared-hosting MTAs split SMTP delivery per `RCPT TO`, so the `To` header alone is not always carried through to Postmark. Append-mode therefore injects `Reply-To: TEST_EMAIL` so the webhook payload always carries the test_id-bearing address.

Every append-aware path injects it at the plugin layer — CF7, Elementor, Fluent, Formidable, Forminator, Gravity Forms, WS Form, WooCommerce via `cv_inject_reply_to_header()`, and WPForms via its own `cv_append_replyto()` — **except Ninja Forms**, which is covered by the `wp_mail` backstop instead.

### Ninja Forms: why it is handled at the backstop

The earlier approach here did not work, and this PR removes it. `ninja_forms_action_email_send` cannot influence the outgoing email at all:

1. It is a plain `apply_filters()`, so `$action_settings` arrives **by value** — any mutation is discarded.
2. NF sends with `$action_settings['to']`; the old code wrote `['email_to']`, a key NF's Email action never reads.
3. NF exposes no filter between `_get_headers()` and `wp_mail()`, so headers are unreachable from that hook.

Verified against Ninja Forms 3.14.11, `includes/Actions/Email.php:57-101`.

The `wp_mail` backstop is therefore the only viable injection point. It now injects Reply-To in append-mode, which fixes NF and any other path that bypasses the per-plugin filters. The injection runs *before* the recipient short-circuit (headers are a separate concern from recipients), and `cv_inject_reply_to_header()` dedups and preserves input type, so helpers that already inject are unaffected.

### Fluent Forms: header filter registration

`fluentform/email_template_header` was registered only in the `disable_email_receipt != 'true'` branch, but that callback is Fluent's sole Reply-To injection point. With `disable_email_receipt` **and** `allow_original_recipients` both set, the filter never registered and append-mode silently lost the MTA-variance defense.

It is now registered in both branches — still gated on `TEST_EMAIL`, so it exists only inside a test session — with a disable-receipt early return in the callback so that path keeps its previous pass-through behavior instead of newly stripping CC/BCC.

## Verification

**Executed** — a standalone harness (no WordPress dependency) exercising the real functions, 22 assertions, all passing:
- `cv_inject_reply_to_header()` (12): idempotency across a helper+backstop double call in both array and string shapes; dedup through `Name <addr>` form; case-insensitive `Reply-To:` detection; bare `Reply-To:` (Elementor Pro emits this) replaced rather than malformed into `Reply-To:, addr`; CRLF header-injection payload neutralized; type preservation; non-array/string passthrough.
- `Checkview_Mail_Redirect::redirect_recipient()` (10): Reply-To injected in the NF case; injected on the early-return path too; **not** injected on the legacy `disable_email_receipt`-only path (scope check); replace-mode byte-identical to before.

**Not executed** — the repo's PHPUnit suite does not run from a normal checkout (`tests/bootstrap.php` resolves WordPress via `dirname(__DIR__, 4)`, which assumes the plugin sits under `wp-content/plugins/`). The `.github/workflows` jobs are wordpress.org SVN update checkers, not test runners, so **nothing validates this PR automatically.**

**Still needed before merge — live runs against a real test session:**
- [ ] Ninja Forms append-mode: confirm the submission reaches both the customer's recipients and the test inbox, with `Reply-To: TEST_EMAIL` present in the Postmark payload. This is the path whose behavior changed most and was verified least.
- [ ] Fluent Forms with `disable_email_receipt=true` **and** `allow_original_recipients=true`: the combination that was previously broken.

## Known gaps (deliberate, not blockers)

- **Everest Forms** has no append-mode awareness. `checkview_inject_email()` replaces recipients with `TEST_EMAIL`, and the backstop then short-circuits because `contains_test_email()` is already true — so `allow_original_recipients` is a no-op there and original recipients are dropped. Everest is absent from the readme's supported-plugin lists.
- **The legacy `disable_email_receipt` append path receives no Reply-To.** This is consistent across every helper (Reply-To is tied exclusively to `allow_original_recipients`), but that path has the same delivery topology and the same MTA exposure. Worth a product decision rather than a silent assumption.

## Coordination

This PR ships first; behavior is a no-op until the SaaS PR (separate, in `checkview-1`) starts sending the flag. Customers must update the helper plugin manually — there is no auto-update mechanism in this codebase, so release notes need to call this out.
