### PR TITLE
fix(gf): defensive backstop for GF 2.7+ honeypot abort path

### DIFF
--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -122,6 +122,40 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 				999
 			);
 
+			// Defensive backstop against the GF 2.7+ honeypot abort path.
+			// Normally Playwright posts the JS-injected `version_hash` back
+			// fine, so honeypot doesn't trip on most sites — but if anything
+			// interferes with that round-trip (e.g. a third-party plugin
+			// that wraps GF's submit button and bypasses GF's pre-submit JS,
+			// or aggressive page caching that serves a stale `version_hash`),
+			// `GF_Honeypot_Handler::handle_abort_submission` short-circuits
+			// `GFFormDisplay::process_form()` BEFORE `handle_submission()`,
+			// returning a success-style confirmation with no saved entry and
+			// no `gform_after_submission` — which surfaces as
+			// `submission-not-found` because `checkview_clone_entry` never
+			// runs. Forcing the abort filter false guarantees the entry is
+			// saved regardless of whether the honeypot heuristic was happy.
+			//
+			// Hook at the submission/validation path (not on
+			// `gform_form_post_get_meta`) so the bypass does not pollute
+			// the persistent `gravityforms_meta` object cache on
+			// Redis/Memcached-backed hosts.
+			// PHP_INT_MAX so we beat any third-party spam plugin that
+			// hooks the same filter at a high priority (Akismet for GF,
+			// CleanTalk, Zero Spam, GravityWiz Anti-Spam, etc.).
+			add_filter(
+				'gform_abort_submission_with_confirmation',
+				'__return_false',
+				PHP_INT_MAX
+			);
+			// Defensive: prevents the cloned entry from being flagged
+			// `status='spam'` if any other GF spam plugin slips through.
+			add_filter(
+				'gform_entry_is_spam',
+				'__return_false',
+				PHP_INT_MAX
+			);
+
 			add_filter(
 				'gform_pre_render',
 				array( $this, 'maybe_hide_recaptcha' )
@@ -175,9 +209,11 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		public function maybe_hide_recaptcha( $form ) {
 			$fields = $form['fields'];
 
+			$spam_field_types = array( 'captcha', 'hcaptcha', 'turnstile', 'honeypot' );
+
 			foreach ( $form['fields'] as $key => $field ) {
-				if ( 'captcha' === $field->type || 'hcaptcha' === $field->type || 'turnstile' === $field->type ) {
-					Checkview_Admin_Logs::add( 'ip-logs', 'Unset captcha field type [' . $field->type . '].' );
+				if ( in_array( $field->type, $spam_field_types, true ) ) {
+					Checkview_Admin_Logs::add( 'ip-logs', 'Unset spam-protection field type [' . $field->type . '].' );
 
 					unset( $fields[ $key ] );
 				}

--- a/tests/test-gf.php
+++ b/tests/test-gf.php
@@ -87,6 +87,40 @@ class Test_Checkview_Gforms_Helper extends WP_UnitTestCase {
 
 
 
+	public function test_constructor_registers_honeypot_bypass_filters() {
+		$this->assertSame( PHP_INT_MAX, has_filter( 'gform_abort_submission_with_confirmation', '__return_false' ) );
+		$this->assertSame( PHP_INT_MAX, has_filter( 'gform_entry_is_spam', '__return_false' ) );
+	}
+
+	public function test_maybe_hide_recaptcha_strips_spam_protection_fields() {
+		$make_field = function ( $type ) {
+			$f       = new stdClass();
+			$f->type = $type;
+			return $f;
+		};
+		$form   = array(
+			'fields' => array(
+				$make_field( 'text' ),
+				$make_field( 'honeypot' ),
+				$make_field( 'captcha' ),
+				$make_field( 'turnstile' ),
+				$make_field( 'hcaptcha' ),
+				$make_field( 'email' ),
+			),
+		);
+		$result = $this->helper->maybe_hide_recaptcha( $form );
+		$types  = array();
+		foreach ( $result['fields'] as $field ) {
+			$types[] = $field->type;
+		}
+		$this->assertContains( 'text', $types );
+		$this->assertContains( 'email', $types );
+		$this->assertNotContains( 'honeypot', $types );
+		$this->assertNotContains( 'captcha', $types );
+		$this->assertNotContains( 'turnstile', $types );
+		$this->assertNotContains( 'hcaptcha', $types );
+	}
+
 	public function test_checkview_disable_zero_spam_addon() {
 		$form_id      = rand( 1, 100 );
 		$should_check = true;


### PR DESCRIPTION
## Summary

- Forces `gform_abort_submission_with_confirmation` and `gform_entry_is_spam` to `false` at `PHP_INT_MAX` inside the GF helper's test-context constructor, so a tripped GF 2.7+ honeypot can't silently drop the form submission and skip `gform_after_submission` (which manifests as `submission-not-found`).
- Extends `maybe_hide_recaptcha()` to also strip the legacy `gfield--type-honeypot` field type at render time (cleaner screenshots, harmless on the 2.7+ JS path).
- Adds two PHPUnit tests covering filter registration and the field-strip behavior.

## Why now

Encore Coatings (https://encorecoatings.com, run `11135b06-b06b-4d20-bd6e-8823a3ed365e`) has been failing `assert_form_submitted` with `submission-not-found`. Helper IP-logs prove the bot/session/cookie pipeline fires correctly and the form-submit POST loads the GF helper. After that, ~85s of silence, then the helper's polling logs:

> Form submission likely succeeded but entry was not captured — the clone handler may not have executed (possible hook failure in form plugin).

That message appears when `wp_cv_entry` is empty AND a `wp_cv_session` row still exists, which happens when `checkview_clone_entry` (hooked on `gform_after_submission` priority 99) never runs. The exact pre-`handle_submission()` short-circuit is `GF_Honeypot_Handler::handle_abort_submission`.

The InstaWP CI test site has both honeypot mechanisms enabled and passes daily without this bypass — so honeypot doesn't trip on most sites. The likely interference on Encore is Simple Cloudflare Turnstile's submit-button wrap (which calls `form.submit()` programmatically and may bypass GF's pre-submit JS that injects `version_hash`). Server then sees an empty/stale hash → honeypot trip → silent abort.

This patch is a **defensive backstop** for that path — it doesn't claim to fix Turnstile interference, just prevents the silent drop that follows.

## Why these hooks (not `gform_form_post_get_meta`)

- `gform_form_post_get_meta` would land the modified meta in the persistent `gravityforms_meta` object cache (Pressable/Redis/Memcached), potentially leaking `enableHoneypot=false` to non-test visitors until TTL/flush. The submission-path filters never touch form meta.
- `PHP_INT_MAX` matches the file's existing convention for must-win bypasses (cf. `gform_validation` → `checkview_bypass_captcha_validation` at PHP_INT_MAX). Beats third-party hooks at default 10/99/999 (Akismet for GF, CleanTalk, Zero Spam, GravityWiz).

## Scope / safety

- The GF helper class is only instantiated inside `Checkview_Admin::checkview_init_current_test()`, which runs only when `Checkview::is_bot()` is true (valid UUID `checkview_test_id` AND visitor IP in CheckView's allowlist). Filter cannot fire for real visitors.
- No version bump (already at 2.0.33 on `development`); changelog/upgrade notice update is a release-time concern.

## Test plan

- [ ] CI: nothing to do — PHPUnit isn't run in the helper's CI; tests are local-only.
- [ ] Local: `composer test` (or equivalent) on `helper/` should pass the two new methods alongside the existing GF suite.
- [ ] After merge → `quality` → InstaWP CI lane: existing `gravityforms&addons.yml` workflow should still go green.
- [ ] Once shipped to Encore (https://encorecoatings.com), re-run the failing flow `Contact Page Form` and confirm `assert_form_submitted` passes and `wp_cv_entry` gets a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)