### PR TITLE
fix: defer FF/NF entry deletion to allow async feed processing

### DIFF
--- a/includes/checkview-functions.php
+++ b/includes/checkview-functions.php
@@ -1161,6 +1161,122 @@ if ( ! function_exists( 'checkview_gf_run_deferred_entry_delete' ) ) {
 	add_action( 'checkview_gf_deferred_entry_delete', 'checkview_gf_run_deferred_entry_delete' );
 }
 
+if ( ! function_exists( 'checkview_ff_should_defer_delete' ) ) {
+	/**
+	 * Whether to defer Fluent Forms entry deletion via cron. Defaults to true (the fix).
+	 *
+	 * Customers can opt out via `define( 'CHECKVIEW_FF_DEFER_ENTRY_DELETE', false );`
+	 * in wp-config.php as an emergency rollback to legacy synchronous deletion.
+	 *
+	 * @return bool
+	 */
+	function checkview_ff_should_defer_delete() {
+		if ( defined( 'CHECKVIEW_FF_DEFER_ENTRY_DELETE' ) && false === CHECKVIEW_FF_DEFER_ENTRY_DELETE ) {
+			return false;
+		}
+		return true;
+	}
+}
+
+if ( ! function_exists( 'checkview_ff_run_deferred_entry_delete' ) ) {
+	/**
+	 * Cron handler: deletes a Fluent Forms entry deferred from form submission.
+	 *
+	 * The deletion is deferred so Fluent Forms Pro async feed processing
+	 * (Mailchimp, Webhooks, Slack, Zapier, HubSpot, Pipedrive, etc.) has time to
+	 * load the submission row and fire third-party integrations. Without this
+	 * delay, queued feed handlers re-fetch the submission ~seconds later and
+	 * silently abort when the row is gone.
+	 *
+	 * @param int $entry_id Fluent Forms submission ID.
+	 * @param int $form_id  Fluent Forms form ID.
+	 * @return void
+	 */
+	function checkview_ff_run_deferred_entry_delete( $entry_id = 0, $form_id = 0 ) {
+		if ( ! function_exists( 'wpFluent' ) ) {
+			return; // Fluent Forms not active anymore — nothing to delete.
+		}
+		$entry_id = (int) $entry_id;
+		$form_id  = (int) $form_id;
+
+		// Defensive: refuse to run with degenerate IDs. FF auto-increments id from 1
+		// and form_id is never zero for real submissions, so a 0/negative pair can
+		// only come from coercion of garbage args (string/array/null) and would
+		// otherwise execute WHERE id=0 AND form_id=0 — a no-op today, but a footgun
+		// if FF ever seeds either column with 0.
+		if ( $entry_id <= 0 || $form_id <= 0 ) {
+			return;
+		}
+
+		wpFluent()->table( 'fluentform_submissions' )
+			->where( 'form_id', $form_id )
+			->where( 'id', '=', $entry_id )
+			->delete();
+		wpFluent()->table( 'fluentform_entry_details' )
+			->where( 'form_id', $form_id )
+			->where( 'submission_id', '=', $entry_id )
+			->delete();
+	}
+	add_action( 'checkview_ff_deferred_entry_delete', 'checkview_ff_run_deferred_entry_delete', 10, 2 );
+}
+
+if ( ! function_exists( 'checkview_nf_should_defer_delete' ) ) {
+	/**
+	 * Whether to defer Ninja Forms entry deletion via cron. Defaults to true
+	 * (the fix).
+	 *
+	 * Customers can opt out via `define( 'CHECKVIEW_NF_DEFER_ENTRY_DELETE', false );`
+	 * in wp-config.php as an emergency rollback to legacy synchronous deletion.
+	 *
+	 * @return bool
+	 */
+	function checkview_nf_should_defer_delete() {
+		if ( defined( 'CHECKVIEW_NF_DEFER_ENTRY_DELETE' ) && false === CHECKVIEW_NF_DEFER_ENTRY_DELETE ) {
+			return false;
+		}
+		return true;
+	}
+}
+
+if ( ! function_exists( 'checkview_nf_run_deferred_entry_delete' ) ) {
+	/**
+	 * Cron handler: deletes a Ninja Forms submission deferred from form
+	 * submission. NF stores submissions as a custom post type (`nf_sub`), so
+	 * deletion is via `wp_delete_post()`.
+	 *
+	 * Defense-in-depth: when `disable_actions=no` (integrations opted in),
+	 * stock NF + Add-Ons Pack runs Mailchimp/Webhooks synchronously inside
+	 * the actions pipeline before the priority-99 cleanup, so there is no
+	 * known async-feed orphaning today. (When `disable_actions=true` —
+	 * the default for tests — those add-ons are stripped from the actions
+	 * list and never run, sync or async.) Deferring matches the FF/GF
+	 * pattern so any future NF add-on that queues async work keyed on the
+	 * `nf_sub` post ID won't silently fail.
+	 *
+	 * @param int $entry_id NF submission post ID.
+	 * @return void
+	 */
+	function checkview_nf_run_deferred_entry_delete( $entry_id = 0 ) {
+		$entry_id = (int) $entry_id;
+		if ( $entry_id <= 0 ) {
+			return;
+		}
+		// Post-type confinement: refuse to delete anything that isn't an NF
+		// submission. wp_delete_post() is type-agnostic, so without this
+		// guard a stale/poisoned cron event with an arbitrary post ID could
+		// force-delete unrelated content (pages, products, attachments).
+		// The FF/GF analogues are inherently scoped (FF to FF tables, GF via
+		// GFAPI::delete_entry); NF needs an explicit check to match.
+		if ( 'nf_sub' !== get_post_type( $entry_id ) ) {
+			return;
+		}
+		// The post may already be gone (admin manual delete, etc.) —
+		// wp_delete_post returns false in that case and is a no-op.
+		wp_delete_post( $entry_id, true );
+	}
+	add_action( 'checkview_nf_deferred_entry_delete', 'checkview_nf_run_deferred_entry_delete' );
+}
+
 add_action(
 	'wp_ajax_checkview_get_status',
 	'checkview_get_option_data_handler'

--- a/includes/formhelpers/class-checkview-fluent-forms-helper.php
+++ b/includes/formhelpers/class-checkview-fluent-forms-helper.php
@@ -256,13 +256,19 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 			return $array_values;
 		}
 		/**
-		 * Stores the test results and finishes the testing session.
+		 * Clones the Fluent Forms submission to cv_entry tables, schedules
+		 * deferred deletion of the source FF rows, and finishes the testing
+		 * session.
 		 *
-		 * Deletes test submission from Formidable database table.
+		 * Deletion is deferred ~15 min so Fluent Forms Pro async feed processing
+		 * (Mailchimp, Webhooks, Slack, Zapier, HubSpot, Pipedrive, etc.) has time
+		 * to load the submission and fire third-party integrations. See
+		 * checkview_ff_should_defer_delete() for the emergency-rollback escape
+		 * hatch (CHECKVIEW_FF_DEFER_ENTRY_DELETE = false).
 		 *
-		 * @param int    $entry_id Fluent Form ID.
-		 * @param array  $form_data Fluent Form data.
-		 * @param object $form Fluent Form object.
+		 * @param int    $entry_id  Fluent Forms submission ID.
+		 * @param array  $form_data Submitted form data.
+		 * @param object $form      Fluent Forms form object.
 		 * @return void
 		 */
 		public function checkview_clone_fluentform_entry( $entry_id, $form_data, $form ) {
@@ -347,15 +353,33 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry data (inserted ' . (int) $result . ' rows into ' . $entry_table . ').' );
 			}
 
-			// remove entry from Fluent forms tables.
-			$delete = wpFluent()->table( 'fluentform_submissions' )
-			->where( 'form_id', $form_id )
-			->where( 'id', '=', $entry_id )
-			->delete();
-			$delete = wpFluent()->table( 'fluentform_entry_details' )
-			->where( 'form_id', $form_id )
-			->where( 'submission_id', '=', $entry_id )
-			->delete();
+			// Remove entry from Fluent Forms tables.
+			//
+			// Deletion is deferred ~15 min to allow Fluent Forms Pro async feed
+			// processing (Mailchimp, Webhooks, Slack, Zapier, HubSpot, Pipedrive,
+			// etc.) to load the submission row and fire third-party integrations.
+			// Without this delay, queued feed handlers re-fetch the submission
+			// seconds later in a separate request and silently abort when the row
+			// is gone — exactly the GF async-feed bug, ported to FF Pro queues.
+			// See checkview_ff_should_defer_delete() for the emergency-rollback
+			// escape hatch (CHECKVIEW_FF_DEFER_ENTRY_DELETE = false).
+			if ( checkview_ff_should_defer_delete() ) {
+				wp_schedule_single_event(
+					time() + 15 * MINUTE_IN_SECONDS,
+					'checkview_ff_deferred_entry_delete',
+					array( (int) $entry_id, (int) $form_id )
+				);
+			} else {
+				// Emergency-rollback escape hatch — legacy synchronous deletion.
+				wpFluent()->table( 'fluentform_submissions' )
+					->where( 'form_id', $form_id )
+					->where( 'id', '=', $entry_id )
+					->delete();
+				wpFluent()->table( 'fluentform_entry_details' )
+					->where( 'form_id', $form_id )
+					->where( 'submission_id', '=', $entry_id )
+					->delete();
+			}
 
 			complete_checkview_test( $checkview_test_id );
 		}

--- a/includes/formhelpers/class-checkview-ninja-forms-helper.php
+++ b/includes/formhelpers/class-checkview-ninja-forms-helper.php
@@ -149,9 +149,19 @@ if ( ! class_exists( 'Checkview_Ninja_Forms_Helper' ) ) {
 			}
 		}
 		/**
-		 * Stores the test results and finishes the testing session.
+		 * Clones the Ninja Forms submission to cv_entry tables, schedules
+		 * deferred deletion of the source `nf_sub` post, and finishes the
+		 * testing session.
 		 *
-		 * Deletes test submission from Formidable database table.
+		 * Deletion is deferred ~15 min as defense-in-depth. When the test
+		 * flow has `disable_actions=no` (integrations opted in), stock NF +
+		 * Add-Ons Pack runs Mailchimp/Webhooks synchronously inside the
+		 * actions pipeline before priority 99, so there is no known
+		 * async-feed orphaning today. Deferring mirrors the FF/GF fix so
+		 * any future NF add-on that queues async work keyed on the
+		 * `nf_sub` post ID won't silently fail. See
+		 * checkview_nf_should_defer_delete() for the emergency-rollback
+		 * escape hatch (CHECKVIEW_NF_DEFER_ENTRY_DELETE = false).
 		 *
 		 * @param array $form_data Form data.
 		 * @return void
@@ -265,7 +275,21 @@ if ( ! class_exists( 'Checkview_Ninja_Forms_Helper' ) ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data.' );
 			}
 
-			wp_delete_post( $entry_id, true );
+			if ( $entry_id > 0 ) {
+				if ( checkview_nf_should_defer_delete() ) {
+					// Defer entry deletion as defense-in-depth so any future NF
+					// add-on that queues async work keyed on the `nf_sub` post ID
+					// has time to run before the post is gone.
+					wp_schedule_single_event(
+						time() + 15 * MINUTE_IN_SECONDS,
+						'checkview_nf_deferred_entry_delete',
+						array( (int) $entry_id )
+					);
+				} else {
+					// Emergency-rollback escape hatch — legacy synchronous deletion.
+					wp_delete_post( $entry_id, true );
+				}
+			}
 
 			complete_checkview_test( $checkview_test_id );
 		}

--- a/tests/test-checkview-functions.php
+++ b/tests/test-checkview-functions.php
@@ -27,4 +27,40 @@ class TestCheckviewFunctions extends WP_UnitTestCase {
 	public function test_should_defer_delete_default_is_true() {
 		$this->assertTrue( checkview_gf_should_defer_delete() );
 	}
+
+	/**
+	 * Confirms the FF deferred-delete cron handler is registered with the
+	 * 'checkview_ff_deferred_entry_delete' action. Regression guard for the
+	 * Fluent Forms async-feed fix.
+	 */
+	public function test_ff_deferred_delete_handler_is_registered() {
+		$priority = has_action( 'checkview_ff_deferred_entry_delete', 'checkview_ff_run_deferred_entry_delete' );
+		$this->assertNotFalse( $priority, 'checkview_ff_run_deferred_entry_delete must be registered on checkview_ff_deferred_entry_delete.' );
+	}
+
+	/**
+	 * checkview_ff_should_defer_delete() defaults to true (the fix is enabled).
+	 * Constant-based opt-out is tested in tests/test-ff-legacy-mode.php.
+	 */
+	public function test_ff_should_defer_delete_default_is_true() {
+		$this->assertTrue( checkview_ff_should_defer_delete() );
+	}
+
+	/**
+	 * Confirms the NF deferred-delete cron handler is registered with the
+	 * 'checkview_nf_deferred_entry_delete' action. Regression guard for the
+	 * Ninja Forms defense-in-depth fix.
+	 */
+	public function test_nf_deferred_delete_handler_is_registered() {
+		$priority = has_action( 'checkview_nf_deferred_entry_delete', 'checkview_nf_run_deferred_entry_delete' );
+		$this->assertNotFalse( $priority, 'checkview_nf_run_deferred_entry_delete must be registered on checkview_nf_deferred_entry_delete.' );
+	}
+
+	/**
+	 * checkview_nf_should_defer_delete() defaults to true (the fix is enabled).
+	 * Constant-based opt-out is tested in tests/test-nf-legacy-mode.php.
+	 */
+	public function test_nf_should_defer_delete_default_is_true() {
+		$this->assertTrue( checkview_nf_should_defer_delete() );
+	}
 }

--- a/tests/test-ff-legacy-mode.php
+++ b/tests/test-ff-legacy-mode.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Tests for the CHECKVIEW_FF_DEFER_ENTRY_DELETE escape hatch constant.
+ *
+ * This file is intentionally separate from tests/test-ff.php because define()
+ * is irreversible within a single PHP process, and the constant set in this
+ * file would pollute other tests that depend on the default (deferred) behavior.
+ *
+ * Filename ordering: tests/test-checkview-functions.php sorts before
+ * tests/test-ff-legacy-mode.php alphabetically, so the registration test in
+ * test-checkview-functions runs first when both run on CI — meaning the
+ * constant defined here cannot leak into the registration test.
+ *
+ * NO plugin gate — checkview_ff_should_defer_delete() is pure PHP (only checks
+ * a constant) and doesn't require Fluent Forms to be loaded. Test runs on CI
+ * for full coverage.
+ *
+ * If anyone adds a second test to this file later that depends on the constant
+ * being unset, they'll need @runInSeparateProcess + @preserveGlobalState
+ * disabled annotations on that test.
+ */
+class TestCheckviewFfLegacyMode extends WP_UnitTestCase {
+
+	/**
+	 * Defining CHECKVIEW_FF_DEFER_ENTRY_DELETE = false should opt out of the
+	 * deferred-delete fix and revert to legacy synchronous deletion behavior.
+	 */
+	public function test_should_defer_delete_respects_constant() {
+		// Default behavior (constant undefined) returns true.
+		if ( ! defined( 'CHECKVIEW_FF_DEFER_ENTRY_DELETE' ) ) {
+			$this->assertTrue( checkview_ff_should_defer_delete(), 'Default behavior should defer.' );
+		}
+
+		// Define the constant to opt out.
+		define( 'CHECKVIEW_FF_DEFER_ENTRY_DELETE', false );
+
+		$this->assertFalse(
+			checkview_ff_should_defer_delete(),
+			'CHECKVIEW_FF_DEFER_ENTRY_DELETE=false must disable deferred deletion (escape hatch).'
+		);
+	}
+}

--- a/tests/test-ff.php
+++ b/tests/test-ff.php
@@ -148,4 +148,153 @@ class Test_Checkview_Fluent_Forms_Helper extends WP_UnitTestCase {
 		delete_option( 'disable_actions_' . $test_id );
 		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
 	}
+
+	public function tearDown(): void {
+		global $wpdb;
+		// Clean up any scheduled deferred-delete events from individual tests.
+		wp_clear_scheduled_hook( 'checkview_ff_deferred_entry_delete' );
+		// Clean up FF rows our tests may have inserted (form_ids 7, 8, 9).
+		// `wpFluent` may not be available in CI; fall back to direct $wpdb when it is missing.
+		if ( function_exists( 'wpFluent' ) ) {
+			wpFluent()->table( 'fluentform_submissions' )->whereIn( 'form_id', array( 7, 8, 9 ) )->delete();
+			wpFluent()->table( 'fluentform_entry_details' )->whereIn( 'form_id', array( 7, 8, 9 ) )->delete();
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * Asserts that checkview_clone_fluentform_entry schedules the deferred-delete
+	 * cron event with the entry id + form id as args, using a delay >= 15 minutes.
+	 *
+	 * Skipped when the legacy-mode escape-hatch constant has been defined (e.g.
+	 * after tests/test-ff-legacy-mode.php runs in the same process), since the
+	 * schedule path is intentionally bypassed in that mode.
+	 */
+	public function test_clone_entry_schedules_deferred_delete() {
+		if ( ! function_exists( 'wpFluent' ) ) {
+			$this->markTestSkipped( 'wpFluent (Fluent Forms) not available in test environment.' );
+		}
+		if ( ! checkview_ff_should_defer_delete() ) {
+			$this->markTestSkipped( 'Defer disabled via CHECKVIEW_FF_DEFER_ENTRY_DELETE — schedule path not exercised.' );
+		}
+
+		$entry_id = 4242;
+		$form_id  = 7;
+		$form     = new stdClass();
+		$form->id = $form_id;
+
+		$_REQUEST['checkview_test_id'] = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+		$this->helper->checkview_clone_fluentform_entry( $entry_id, array(), $form );
+		unset( $_REQUEST['checkview_test_id'] );
+
+		$scheduled = wp_next_scheduled( 'checkview_ff_deferred_entry_delete', array( $entry_id, $form_id ) );
+		$this->assertNotFalse( $scheduled, 'Deferred-delete event should be scheduled.' );
+		$this->assertGreaterThanOrEqual( time() + ( 15 * MINUTE_IN_SECONDS ) - 60, $scheduled, 'Schedule should be at least ~15 min in the future.' );
+	}
+
+	/**
+	 * Asserts that checkview_clone_fluentform_entry does NOT delete the FF
+	 * submission row synchronously when the defer fix is active. The row should
+	 * still exist after clone returns; the deferred cron is responsible for
+	 * deletion ~15 min later.
+	 *
+	 * Skipped when the legacy-mode escape-hatch constant has been defined, since
+	 * the synchronous-delete path is the expected behavior in that mode.
+	 */
+	public function test_clone_entry_does_not_delete_synchronously() {
+		if ( ! function_exists( 'wpFluent' ) ) {
+			$this->markTestSkipped( 'wpFluent (Fluent Forms) not available in test environment.' );
+		}
+		if ( ! checkview_ff_should_defer_delete() ) {
+			$this->markTestSkipped( 'Defer disabled via CHECKVIEW_FF_DEFER_ENTRY_DELETE — synchronous delete is expected.' );
+		}
+
+		$form_id  = 8;
+		$entry_id = wpFluent()->table( 'fluentform_submissions' )->insertGetId(
+			array(
+				'form_id'       => $form_id,
+				'serial_number' => 1,
+				'response'      => '{}',
+				'status'        => 'unread',
+				'source_url'    => 'https://example.test/',
+				'user_id'       => 0,
+				'browser'       => 'phpunit',
+				'ip'            => '127.0.0.1',
+				'created_at'    => current_time( 'mysql' ),
+				'updated_at'    => current_time( 'mysql' ),
+			)
+		);
+		if ( ! $entry_id ) {
+			$this->markTestSkipped( 'Could not insert test FF submission.' );
+		}
+
+		$form     = new stdClass();
+		$form->id = $form_id;
+
+		$_REQUEST['checkview_test_id'] = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+		$this->helper->checkview_clone_fluentform_entry( $entry_id, array(), $form );
+		unset( $_REQUEST['checkview_test_id'] );
+
+		$row = wpFluent()->table( 'fluentform_submissions' )
+			->where( 'id', $entry_id )
+			->first();
+		$this->assertNotNull( $row, 'FF submission row should still exist after clone (deletion deferred).' );
+
+		// Cleanup.
+		wpFluent()->table( 'fluentform_submissions' )->where( 'id', $entry_id )->delete();
+	}
+
+	/**
+	 * Asserts that the deferred handler actually deletes the FF submission +
+	 * entry_details rows when run.
+	 */
+	public function test_deferred_handler_deletes_entry() {
+		if ( ! function_exists( 'wpFluent' ) ) {
+			$this->markTestSkipped( 'wpFluent (Fluent Forms) not available in test environment.' );
+		}
+
+		$form_id  = 9;
+		$entry_id = wpFluent()->table( 'fluentform_submissions' )->insertGetId(
+			array(
+				'form_id'       => $form_id,
+				'serial_number' => 1,
+				'response'      => '{}',
+				'status'        => 'unread',
+				'source_url'    => 'https://example.test/',
+				'user_id'       => 0,
+				'browser'       => 'phpunit',
+				'ip'            => '127.0.0.1',
+				'created_at'    => current_time( 'mysql' ),
+				'updated_at'    => current_time( 'mysql' ),
+			)
+		);
+		if ( ! $entry_id ) {
+			$this->markTestSkipped( 'Could not insert test FF submission.' );
+		}
+		wpFluent()->table( 'fluentform_entry_details' )->insert(
+			array(
+				'form_id'       => $form_id,
+				'submission_id' => $entry_id,
+				'field_name'    => 'email',
+				'sub_field_name' => '',
+				'field_value'   => 'phpunit@example.test',
+			)
+		);
+
+		// Sanity: rows exist before handler runs.
+		$this->assertNotNull(
+			wpFluent()->table( 'fluentform_submissions' )->where( 'id', $entry_id )->first()
+		);
+
+		checkview_ff_run_deferred_entry_delete( $entry_id, $form_id );
+
+		$this->assertNull(
+			wpFluent()->table( 'fluentform_submissions' )->where( 'id', $entry_id )->first(),
+			'Handler should have deleted the FF submission row.'
+		);
+		$this->assertNull(
+			wpFluent()->table( 'fluentform_entry_details' )->where( 'submission_id', $entry_id )->first(),
+			'Handler should have deleted the FF entry_details rows.'
+		);
+	}
 }

--- a/tests/test-nf-legacy-mode.php
+++ b/tests/test-nf-legacy-mode.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Tests for the CHECKVIEW_NF_DEFER_ENTRY_DELETE escape hatch constant.
+ *
+ * This file is intentionally separate from tests/test-nf.php because define()
+ * is irreversible within a single PHP process, and the constant set in this
+ * file would pollute other tests that depend on the default (deferred) behavior.
+ *
+ * Filename ordering: tests/test-checkview-functions.php sorts before
+ * tests/test-nf-legacy-mode.php alphabetically, so the registration test in
+ * test-checkview-functions runs first when both run on CI — meaning the
+ * constant defined here cannot leak into the registration test.
+ *
+ * NO plugin gate — checkview_nf_should_defer_delete() is pure PHP (only checks
+ * a constant) and doesn't require Ninja Forms to be loaded. Test runs on CI
+ * for full coverage.
+ *
+ * If anyone adds a second test to this file later that depends on the constant
+ * being unset, they'll need @runInSeparateProcess + @preserveGlobalState
+ * disabled annotations on that test.
+ */
+class TestCheckviewNfLegacyMode extends WP_UnitTestCase {
+
+	/**
+	 * Defining CHECKVIEW_NF_DEFER_ENTRY_DELETE = false should opt out of the
+	 * deferred-delete fix and revert to legacy synchronous deletion behavior.
+	 */
+	public function test_should_defer_delete_respects_constant() {
+		// Default behavior (constant undefined) returns true.
+		if ( ! defined( 'CHECKVIEW_NF_DEFER_ENTRY_DELETE' ) ) {
+			$this->assertTrue( checkview_nf_should_defer_delete(), 'Default behavior should defer.' );
+		}
+
+		// Define the constant to opt out.
+		define( 'CHECKVIEW_NF_DEFER_ENTRY_DELETE', false );
+
+		$this->assertFalse(
+			checkview_nf_should_defer_delete(),
+			'CHECKVIEW_NF_DEFER_ENTRY_DELETE=false must disable deferred deletion (escape hatch).'
+		);
+	}
+}

--- a/tests/test-nf.php
+++ b/tests/test-nf.php
@@ -125,4 +125,108 @@ class Checkview_Ninja_Forms_Helper_Test extends WP_UnitTestCase {
 		delete_option( 'disable_actions_' . $test_id );
 		unset( $_REQUEST['checkview_test_id'] );
 	}
+
+	public function tearDown(): void {
+		// Clean up any scheduled deferred-delete events from individual tests.
+		wp_clear_scheduled_hook( 'checkview_nf_deferred_entry_delete' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Asserts that checkview_clone_entry schedules the deferred-delete cron
+	 * event with the entry id as args, using a delay >= 15 minutes.
+	 *
+	 * Skipped when the legacy-mode escape-hatch constant has been defined
+	 * (e.g. after tests/test-nf-legacy-mode.php runs in the same process),
+	 * since the schedule path is intentionally bypassed in that mode.
+	 */
+	public function test_clone_entry_schedules_deferred_delete() {
+		if ( ! checkview_nf_should_defer_delete() ) {
+			$this->markTestSkipped( 'Defer disabled via CHECKVIEW_NF_DEFER_ENTRY_DELETE — schedule path not exercised.' );
+		}
+
+		// Create a real `nf_sub` post so the deletion target is valid; clone
+		// also reads $_POST['formData'], which we can leave empty for this test.
+		$entry_id = wp_insert_post(
+			array(
+				'post_type'   => 'nf_sub',
+				'post_status' => 'publish',
+				'post_title'  => 'CV NF test sub',
+			)
+		);
+		$this->assertNotInstanceOf( 'WP_Error', $entry_id );
+		$this->assertGreaterThan( 0, $entry_id );
+
+		$form_data = array(
+			'form_id' => 5150,
+			'actions' => array(
+				'save' => array(
+					'sub_id' => (int) $entry_id,
+				),
+			),
+			'fields'  => array(),
+		);
+
+		$_REQUEST['checkview_test_id'] = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+		$this->helper->checkview_clone_entry( $form_data );
+		unset( $_REQUEST['checkview_test_id'] );
+
+		$scheduled = wp_next_scheduled( 'checkview_nf_deferred_entry_delete', array( (int) $entry_id ) );
+		$this->assertNotFalse( $scheduled, 'Deferred-delete event should be scheduled.' );
+		$this->assertGreaterThanOrEqual( time() + ( 15 * MINUTE_IN_SECONDS ) - 60, $scheduled, 'Schedule should be at least ~15 min in the future.' );
+
+		// The post should still exist (deletion is deferred, not synchronous).
+		$this->assertEquals( 'nf_sub', get_post_type( $entry_id ), 'Source post should still exist after clone (deletion deferred).' );
+
+		// Cleanup.
+		wp_delete_post( $entry_id, true );
+	}
+
+	/**
+	 * Asserts that the deferred handler actually deletes the `nf_sub` post
+	 * when run.
+	 */
+	public function test_deferred_handler_deletes_entry() {
+		$entry_id = wp_insert_post(
+			array(
+				'post_type'   => 'nf_sub',
+				'post_status' => 'publish',
+				'post_title'  => 'CV NF deferred handler test',
+			)
+		);
+		$this->assertNotInstanceOf( 'WP_Error', $entry_id );
+		$this->assertGreaterThan( 0, $entry_id );
+
+		// Sanity: post exists before handler runs.
+		$this->assertEquals( 'nf_sub', get_post_type( $entry_id ) );
+
+		checkview_nf_run_deferred_entry_delete( $entry_id );
+
+		$this->assertNull( get_post( $entry_id ), 'Handler should have deleted the nf_sub post.' );
+	}
+
+	/**
+	 * Asserts that the deferred handler refuses to delete posts that are
+	 * not of post type `nf_sub`. Defends against a poisoned/typo'd cron
+	 * event force-deleting unrelated content (pages, products, attachments).
+	 */
+	public function test_deferred_handler_refuses_foreign_post_type() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'CV NF foreign post-type guard test',
+			)
+		);
+		$this->assertNotInstanceOf( 'WP_Error', $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+		$this->assertEquals( 'post', get_post_type( $post_id ) );
+
+		checkview_nf_run_deferred_entry_delete( $post_id );
+
+		$this->assertNotNull( get_post( $post_id ), 'Handler must refuse to delete non-nf_sub posts.' );
+
+		// Cleanup.
+		wp_delete_post( $post_id, true );
+	}
 }


### PR DESCRIPTION
## Summary

- **FF (active bug)**: Fluent Forms Pro Mailchimp / Webhook / Slack / Zapier / HubSpot / Pipedrive integrations have been silently failing on CheckView tests. The helper deleted the FF submission row inline at `fluentform/before_submission_confirmation`, but FF Pro's `GlobalNotificationHandler` queues async feeds via Action Scheduler (`as_enqueue_async_action('fluentform/schedule_feed', [queueId])`); the queued handler runs in a later request and re-fetches the submission from `fluentform_submissions` / `fluentform_entry_details`. With the inline delete those rows are gone, the integration's `notify()` gets nothing, and the customer never sees the subscriber.
- **NF (defense-in-depth)**: NF's `wp_delete_post( $entry_id, true )` at `ninja_forms_after_submission` priority 99 is currently safe — Add-Ons Pack runs Mailchimp/Webhooks synchronously inside the actions pipeline before priority 99 when `disable_actions=no`. Defers anyway so any future async NF add-on doesn't hit the same trap. Cron handler also confines to `post_type='nf_sub'` since `wp_delete_post` is otherwise type-agnostic.
- Same defer pattern as the merged GF fix in `c3cf4d9` (PR #194). Same escape-hatch ergonomics (`CHECKVIEW_FF_DEFER_ENTRY_DELETE = false` / `CHECKVIEW_NF_DEFER_ENTRY_DELETE = false`).

## Why this isn't smaller

**Why is NF in this PR (it's defense-in-depth, not a live bug)?** Symmetric pattern; reads better as a single "form-helper defer pattern" change than as two unrelated PRs. Each form keeps its own escape hatch, so blast radius is bounded per form.

**Why two separate `*-legacy-mode.php` test files?** `define()` is irreversible per process; isolating each constant in its own file prevents pollution of the schedule-path tests. Alternative was `@runInSeparateProcess` per test — file separation is more readable and matches the GF precedent.

**Why an escape-hatch constant?** Matches GF c3cf4d9 ergonomics — gives ops a 30-second rollback if FF Pro ever changes the table schema and the deferred delete starts erroring.

**Retracts the FF claim in `c3cf4d9`** ("FF architecturally cannot trigger this bug, no async-feed framework"). Audit confirmed that was wrong — FF Pro absolutely uses Action Scheduler for integration feeds.

## Audit of other form helpers

Verified clean — no similar bug:

- **GF** (selective-yak InstaWP site): `c3cf4d9` already fixed; suppression hook properly gated.
- **WS Form** (luckiest-gecko): no row deletion in helper, suppression hook properly gated, no async-feed framework.
- **WPForms** (cheapest-crayfish): Mailchimp addon hooks `wpforms_process_complete` at priority 10 — fires before helper's priority-99 deletion; AS task payload is inlined so no submission re-fetch.
- **Formidable** (funny-hornet): Mailchimp fires synchronously at priority 20 before priority-99 deletion; suppression filter properly gated.
- **CF7**: no integrations to test.

## What's in the diff

- `includes/checkview-functions.php`: `checkview_ff_should_defer_delete()` + `checkview_ff_run_deferred_entry_delete()` (FF), `checkview_nf_should_defer_delete()` + `checkview_nf_run_deferred_entry_delete()` (NF). Defensive int cast + `<=0` guards + PHP 8 default param values. NF handler also enforces `'nf_sub' === get_post_type()`.
- `includes/formhelpers/class-checkview-fluent-forms-helper.php`: replace synchronous `wpFluent()->...->delete()` calls with `wp_schedule_single_event(time() + 15 * MINUTE_IN_SECONDS, 'checkview_ff_deferred_entry_delete', [$entry_id, $form_id])`. Updated docblock.
- `includes/formhelpers/class-checkview-ninja-forms-helper.php`: replace synchronous `wp_delete_post()` with deferred schedule. Updated misleading "Formidable database table" docblock (carry-over from a prior copy-paste).
- `tests/`: registration + default-true + behavior + escape-hatch + foreign-post-type guard tests. New `test-ff-legacy-mode.php` and `test-nf-legacy-mode.php` for `define()`-isolated escape-hatch coverage.

## Test plan

- [ ] Manual: trigger a CheckView test on `intricate-jellyfish-a6a93b.instawp.xyz` (FF + Mailchimp + Webhook configured, `disable_actions=no`). Confirm Mailchimp audience gets the subscriber and Webhook endpoint receives the POST within ~1 minute. Confirm the FF submission row gets cleaned up by the cron event ~15 min later.
- [ ] Manual: trigger a CheckView test on `evaluative-trout-103fa6.instawp.xyz` (NF). Confirm Mailchimp + Webhook still fire (no regression). Confirm the `nf_sub` post is cleaned up ~15 min later.
- [ ] Manual: with `disable_actions=yes`, confirm integrations are still suppressed (existing behavior unchanged on both forms).
- [ ] Emergency-rollback: `define('CHECKVIEW_FF_DEFER_ENTRY_DELETE', false)` reverts to legacy sync deletion path; same for NF.
- [ ] PHPUnit: `phpunit tests/test-checkview-functions.php tests/test-ff*.php tests/test-nf*.php` (note: helper plugin's CI doesn't currently wire PHPUnit to GitHub Actions — tests serve as documentation + manual run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)