### PR TITLE
docs: complete 2.0.33 changelog with all shipped + in-flight fixes

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -206,11 +206,19 @@ Support and test configuration are handled through the CheckView platform. Pleas
 == Changelog ==
 
 = 2.0.33 =
+* Fix Ninja Forms reCAPTCHA bypass: non-essential NF actions (reCAPTCHA, webhooks, payment, CRM) are now disabled unconditionally during CheckView tests so `ninja_forms_after_submission` can fire and submissions can be captured.
+* Add Gravity Forms reCAPTCHA Add-On (v2.x) bypass via `gform_validation` filter at `PHP_INT_MAX`, registered only when `is_bot()` is true.
+* Tighten security on `remove_gravityforms_recaptcha_addon()` — now requires a valid UUIDv4 + test_type instead of a bare `isset()` check.
+* Switch `checkview_my_hcap_activate()` from `isset()` to `CheckView::is_bot()` and guard `checkview_get_visitor_ip()` before the bot check to avoid fatals on hCaptcha activation.
 * Fix form page dropdown returning Kadence Element (popup/hook) container URLs instead of real display URLs.
 * Add `kadence_element` post type to the form-host page exclusion list across all supported form plugins, reusable block recursion, and the WPForms location-meta lookup.
-* Properly disable non-essential Ninja Forms actions during CheckView tests.
-* Fix Fluent Forms disable_actions handler stripping the native email feed alongside third-party integrations during CheckView tests, causing `assert_email_received` to time out.
-* Fluent Forms disable_actions handler now preserves the native `notifications` feed key while still suppressing third-party feeds (slack, mailchimp, webhook, zapier, etc.).
+* Fix Contact Form 7 file uploads not being discoverable by CheckView SaaS validation: files are now also stored under the original input name (in addition to the legacy `{name}cv_cf7_file` key) so `assert_form_submitted` correctly verifies CF7 uploads instead of silently passing on broken forms.
+* Fix Fluent Forms disable_actions handler stripping the native email feed alongside third-party integrations during CheckView tests, causing `assert_email_received` to time out. The handler now preserves the native `notifications` feed key while still suppressing third-party feeds (slack, mailchimp, webhook, zapier, etc.).
+* Fix Gravity Forms async feed integrations (Mailchimp, Webhooks, Zapier, etc.) silently failing on CheckView tests: GF entry deletion is now deferred 15 minutes via `wp_schedule_single_event` so `GF_Background_Process` can re-fetch the entry. Emergency rollback: `define( 'CHECKVIEW_GF_DEFER_ENTRY_DELETE', false )`.
+* Fix Fluent Forms Pro async feed integrations (Mailchimp, Webhook, Slack, Zapier, HubSpot, Pipedrive) silently failing on CheckView tests: FF submission deletion is now deferred so `GlobalNotificationHandler`'s queued Action Scheduler feeds can complete. Emergency rollback: `define( 'CHECKVIEW_FF_DEFER_ENTRY_DELETE', false )`.
+* Defer Ninja Forms submission deletion as defense-in-depth against future async NF add-ons (current Add-Ons Pack runs Mailchimp/Webhooks before priority 99 and is unaffected). Cron handler is confined to `post_type='nf_sub'` so a poisoned cron event cannot delete unrelated content. Emergency rollback: `define( 'CHECKVIEW_NF_DEFER_ENTRY_DELETE', false )`.
+* Wire the `disable_actions` flow-level toggle end-to-end on Contact Form 7 and Ninja Forms — previously CF7 had no support and NF always suppressed regardless of the flag. New CF7 enumerator removes third-party callbacks on `wpcf7_before_send_mail` / `wpcf7_mail_sent` while preserving WPCF7 core, Closures, and CheckView's own callbacks. NF now respects the per-test option instead of suppressing unconditionally.
+* Harden the `disable_actions` request-param parser to strict equality (`'true' === $disable_actions`) so the literal string `'false'` is no longer treated as truthy.
 
 = 2.0.32 =
 * Fix WP Forms simple name fields.

--- a/README.txt
+++ b/README.txt
@@ -578,9 +578,19 @@ Support and test configuration are handled through the CheckView platform. Pleas
 == Upgrade Notice ==
 
 = 2.0.33 =
-* Properly disable non-essential Ninja Forms actions during CheckView tests.
-* Fix Fluent Forms disable_actions handler stripping the native email feed alongside third-party integrations during CheckView tests, causing `assert_email_received` to time out.
-* Fluent Forms disable_actions handler now preserves the native `notifications` feed key while still suppressing third-party feeds (slack, mailchimp, webhook, zapier, etc.).
+* Fix Ninja Forms reCAPTCHA bypass: non-essential NF actions (reCAPTCHA, webhooks, payment, CRM) are now disabled unconditionally during CheckView tests so `ninja_forms_after_submission` can fire and submissions can be captured.
+* Add Gravity Forms reCAPTCHA Add-On (v2.x) bypass via `gform_validation` filter at `PHP_INT_MAX`, registered only when `is_bot()` is true.
+* Tighten security on `remove_gravityforms_recaptcha_addon()` — now requires a valid UUIDv4 + test_type instead of a bare `isset()` check.
+* Switch `checkview_my_hcap_activate()` from `isset()` to `CheckView::is_bot()` and guard `checkview_get_visitor_ip()` before the bot check to avoid fatals on hCaptcha activation.
+* Fix form page dropdown returning Kadence Element (popup/hook) container URLs instead of real display URLs.
+* Add `kadence_element` post type to the form-host page exclusion list across all supported form plugins, reusable block recursion, and the WPForms location-meta lookup.
+* Fix Contact Form 7 file uploads not being discoverable by CheckView SaaS validation: files are now also stored under the original input name (in addition to the legacy `{name}cv_cf7_file` key) so `assert_form_submitted` correctly verifies CF7 uploads instead of silently passing on broken forms.
+* Fix Fluent Forms disable_actions handler stripping the native email feed alongside third-party integrations during CheckView tests, causing `assert_email_received` to time out. The handler now preserves the native `notifications` feed key while still suppressing third-party feeds (slack, mailchimp, webhook, zapier, etc.).
+* Fix Gravity Forms async feed integrations (Mailchimp, Webhooks, Zapier, etc.) silently failing on CheckView tests: GF entry deletion is now deferred 15 minutes via `wp_schedule_single_event` so `GF_Background_Process` can re-fetch the entry. Emergency rollback: `define( 'CHECKVIEW_GF_DEFER_ENTRY_DELETE', false )`.
+* Fix Fluent Forms Pro async feed integrations (Mailchimp, Webhook, Slack, Zapier, HubSpot, Pipedrive) silently failing on CheckView tests: FF submission deletion is now deferred so `GlobalNotificationHandler`'s queued Action Scheduler feeds can complete. Emergency rollback: `define( 'CHECKVIEW_FF_DEFER_ENTRY_DELETE', false )`.
+* Defer Ninja Forms submission deletion as defense-in-depth against future async NF add-ons (current Add-Ons Pack runs Mailchimp/Webhooks before priority 99 and is unaffected). Cron handler is confined to `post_type='nf_sub'` so a poisoned cron event cannot delete unrelated content. Emergency rollback: `define( 'CHECKVIEW_NF_DEFER_ENTRY_DELETE', false )`.
+* Wire the `disable_actions` flow-level toggle end-to-end on Contact Form 7 and Ninja Forms — previously CF7 had no support and NF always suppressed regardless of the flag. New CF7 enumerator removes third-party callbacks on `wpcf7_before_send_mail` / `wpcf7_mail_sent` while preserving WPCF7 core, Closures, and CheckView's own callbacks. NF now respects the per-test option instead of suppressing unconditionally.
+* Harden the `disable_actions` request-param parser to strict equality (`'true' === $disable_actions`) so the literal string `'false'` is no longer treated as truthy.
 
 = 2.0.32 =
 * Fix WP Forms simple name fields.


### PR DESCRIPTION
## Summary
- The existing 2.0.33 changelog in `README.txt` only listed a subset of the PRs landed on `development` since `Release v2.0.32`.
- Adds bullets for every remaining fix so the 2.0.33 ship notes are complete.
- Audited end-to-end with 5 parallel subagents: commit-by-commit coverage, technical accuracy vs. code (PHP_INT_MAX priority, 15-min cron window, hook names, escape-hatch constants, dual-key CF7 storage, `nf_sub` confinement, `is_bot()` switch — all verified), and Launchpad / ClickUp ticket cross-reference.

## Coverage map (helper PRs since 2.0.32)
| PR | Bullet |
|---|---|
| #188 NF disable non-essential actions | added |
| #189 GF reCAPTCHA Add-On bypass + security tightening | added |
| de3a57d hcap_activate `is_bot()` + IP guard | added |
| #190 Kadence Element page dropdown | already present |
| #192 CF7 file uploads under original name | added |
| #193 FF disable_actions preserve native email | already present |
| #194 GF defer entry deletion 15 min | added |
| #195 disable_actions end-to-end on CF7 + NF | added |
| #199 FF/NF defer entry deletion | added |

## Other open helper PRs to weigh in on for 2.0.33 scope
No changelog entries here yet — please decide:
- **PR #198** — defensive backstop for GF 2.7+ honeypot abort path (pairs naturally with the GF reCAPTCHA work already in 2.0.33).
- **PR #197** — `feat: allow_original_recipients` append-mode for test emails (new feature, not a fix).

## Test plan
- [ ] Confirm rendered changelog reads cleanly on the WordPress.org plugin readme parser.
- [ ] Decide on PRs #197/#198 scope; add bullets if shipping.