### PR TITLE
fix(wpforms): honor disable_actions by purging third-party listeners

### DIFF
--- a/includes/formhelpers/class-checkview-wpforms-helper.php
+++ b/includes/formhelpers/class-checkview-wpforms-helper.php
@@ -70,6 +70,13 @@ if ( ! class_exists( 'Checkview_Wpforms_Helper' ) ) {
 				20
 			);
 
+			// IMPORTANT: register as `array( $this, 'method' )`, not as a static
+			// `array( __CLASS__, 'method' )` — checkview_wpforms_disable_addons()
+			// whitelists this callback via `instanceof Checkview_Wpforms_Helper`
+			// on $cb['function'][0]. A static-method registration would store a
+			// string class name in slot 0, fail the instance check, and our own
+			// cloning callback would be silently purged alongside third-party
+			// listeners under disable_actions.
 			add_action(
 				'wpforms_process_complete',
 				array(
@@ -137,6 +144,89 @@ if ( ! class_exists( 'Checkview_Wpforms_Helper' ) ) {
 				99,
 				1
 			);
+
+			add_action(
+				'wpforms_process',
+				array(
+					$this,
+					'checkview_wpforms_disable_addons',
+				),
+				1,
+				3
+			);
+		}
+
+		/**
+		 * Suppress third-party integrations on wpforms_process_complete when the
+		 * test flow's disable_actions flag is set.
+		 *
+		 * Hooks early on wpforms_process (which fires before wpforms_process_complete)
+		 * and walks the global $wp_filter, removing every callback registered on
+		 * wpforms_process_complete and its form-id-scoped variant — except this
+		 * helper's own checkview_log_wpform_test_entry, which clones the submission
+		 * into the cv_entry / cv_entry_meta tables. Whitelisting by class instance
+		 * (not priority) survives any future priority change to our own callback.
+		 *
+		 * Why blanket removal: WPForms providers (Mailchimp, ActiveCampaign,
+		 * ConvertKit, Salesforce, Drip, Sendinblue, Zoho), the User Registration
+		 * addon, the Post Submissions addon, the Webhooks addon, and any custom
+		 * site code all hook wpforms_process_complete. Stripping individual
+		 * form_data keys would miss addons (User Registration / Post Submissions)
+		 * that read from $form_data['settings'] sub-keys and any custom code that
+		 * doesn't read form_data at all. Removing all listeners is the same
+		 * pattern the everest-forms helper uses.
+		 *
+		 * Preserved side effects (NOT on this hook):
+		 * - Native email notifications fire via WPForms_Process::process_emails(),
+		 *   a direct call after the action returns, so assert_email_received still
+		 *   receives the confirmation mail at <test_run_id>@test-mail.checkview.io.
+		 * - Entry save into wpforms_entries happens earlier in entry_save(); the
+		 *   row exists by the time our cloning callback runs.
+		 *
+		 * @param array $fields    Form fields.
+		 * @param array $entry     Entry data.
+		 * @param array $form_data Form data and settings.
+		 *
+		 * @return void
+		 */
+		public function checkview_wpforms_disable_addons( $fields, $entry, $form_data ) {
+			$cv_test_id = get_checkview_test_id();
+			if ( ! $cv_test_id || 'true' !== get_option( 'disable_actions_' . $cv_test_id, false ) ) {
+				return;
+			}
+
+			global $wp_filter;
+			$form_id = isset( $form_data['id'] ) ? (int) $form_data['id'] : 0;
+			$hooks   = array( 'wpforms_process_complete' );
+			if ( $form_id ) {
+				$hooks[] = 'wpforms_process_complete_' . $form_id;
+			}
+
+			$removed_count = 0;
+			foreach ( $hooks as $hook ) {
+				if ( ! isset( $wp_filter[ $hook ] ) || empty( $wp_filter[ $hook ]->callbacks ) ) {
+					continue;
+				}
+				foreach ( $wp_filter[ $hook ]->callbacks as $priority => $callbacks ) {
+					foreach ( $callbacks as $cb_id => $cb ) {
+						if (
+							is_array( $cb['function'] ) &&
+							isset( $cb['function'][0] ) &&
+							is_object( $cb['function'][0] ) &&
+							$cb['function'][0] instanceof Checkview_Wpforms_Helper
+						) {
+							continue;
+						}
+						unset( $wp_filter[ $hook ]->callbacks[ $priority ][ $cb_id ] );
+						$removed_count++;
+					}
+					if ( empty( $wp_filter[ $hook ]->callbacks[ $priority ] ) ) {
+						unset( $wp_filter[ $hook ]->callbacks[ $priority ] );
+					}
+				}
+			}
+
+			Checkview_Admin_Logs::add( 'ip-logs', 'WPForms: removed ' . $removed_count . ' third-party listener(s) from wpforms_process_complete under disable_actions.' );
 		}
 
 		/**

--- a/tests/test-fdf.php
+++ b/tests/test-fdf.php
@@ -22,39 +22,6 @@ class Test_Checkview_Formidable_Helper extends WP_UnitTestCase {
 		$this->assertEquals( TEST_EMAIL, $result );
 	}
 
-	// public function test_checkview_log_form_test_entry() {
-	// global $wpdb;
-
-	// $checkview_formidable_helper = new Checkview_Formidable_Helper();
-	// $form_id = 123;
-	// $entry_id = 456;
-
-	// Test data.
-	// $test_data = array(
-	// 'form_id' => $form_id,
-	// 'status' => 'publish',
-	// 'source_url' => 'http://example.com',
-	// 'date_created' => current_time( 'mysql' ),
-	// 'date_updated' => current_time( 'mysql' ),
-	// 'uid' => 'test_uid',
-	// 'form_type' => 'Formidable',
-	// );
-
-	// Insert test data into the database.
-	// $wpdb->insert( $wpdb->prefix . 'cv_entry', $test_data );
-	// $inserted_entry_id = $wpdb->insert_id;
-
-	// Test the function.
-	// $checkview_formidable_helper->checkview_log_form_test_entry( $entry_id, $form_id );
-
-	// Check if the data was inserted correctly.
-	// $entry_data = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM ' . $wpdb->prefix . 'cv_entry WHERE id=%d', $inserted_entry_id ), ARRAY_A );
-	// $this->assertEquals( 'test_uid', $entry_data['uid'] );
-
-	// Clean up.
-	// $wpdb->query( $wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . 'cv_entry WHERE id=%d', $inserted_entry_id ) );
-	// }
-
 	public function test_get_form_fields() {
 		$checkview_formidable_helper = new Checkview_Formidable_Helper();
 		$form_id                     = rand( 1, 100 );
@@ -96,6 +63,73 @@ class Test_Checkview_Formidable_Helper extends WP_UnitTestCase {
 		foreach ( $test_data as $data ) {
 			$wpdb->query( $wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . 'frm_fields WHERE id=%d', $data['id'] ) );
 		}
+	}
+
+	public function test_disable_form_actions_keeps_email_action_when_flag_set() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$helper = new Checkview_Formidable_Helper();
+		$action = (object) array( 'post_excerpt' => 'email' );
+		$result = $helper->checkview_disable_form_actions( true, $action, null, null, 'create' );
+		$this->assertFalse( $result, 'Email action must run (false = do not skip) even when disable_actions is set.' );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_form_actions_keeps_register_action_when_flag_set() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$helper = new Checkview_Formidable_Helper();
+		$action = (object) array( 'post_excerpt' => 'register' );
+		$result = $helper->checkview_disable_form_actions( true, $action, null, null, 'create' );
+		$this->assertFalse( $result );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_form_actions_keeps_on_submit_action_when_flag_set() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$helper = new Checkview_Formidable_Helper();
+		$action = (object) array( 'post_excerpt' => 'on_submit' );
+		$result = $helper->checkview_disable_form_actions( true, $action, null, null, 'create' );
+		$this->assertFalse( $result );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_form_actions_skips_third_party_when_flag_set() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$helper = new Checkview_Formidable_Helper();
+		$action = (object) array( 'post_excerpt' => 'mailchimp' );
+		$result = $helper->checkview_disable_form_actions( false, $action, null, null, 'create' );
+		$this->assertTrue( $result, 'Third-party action must be skipped (true = skip) when disable_actions is set.' );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_form_actions_third_party_runs_without_flag() {
+		$helper = new Checkview_Formidable_Helper();
+		$action = (object) array( 'post_excerpt' => 'mailchimp' );
+		$result = $helper->checkview_disable_form_actions( false, $action, null, null, 'create' );
+		$this->assertFalse( $result, 'Third-party action runs (false = do not skip) when disable_actions is unset.' );
 	}
 
 	public function test_remove_recaptcha_field_from_list() {

--- a/tests/test-gf.php
+++ b/tests/test-gf.php
@@ -33,53 +33,6 @@ class Test_Checkview_Gforms_Helper extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'Checkview_Gforms_Helper', $this->helper );
 	}
 
-	public function test_checkview_clone_entry() {
-		$entry    = array(
-			'id'      => 1,
-			'form_id' => 1,
-		);
-		$form     = new stdClass();
-		$form->id = 1;
-
-		// Mock the get_checkview_test_id function to return a test ID
-		$this->mock_get_checkview_test_id( 'test_id' );
-
-		// Mock the checkview_clone_gf_entry method to return true
-		$this->mock_checkview_clone_gf_entry( true );
-
-		// Mock the GFAPI::delete_entry method to return true
-		$this->mock_GFAPIDeleteEntry( true );
-		$this->mock_complete_checkview_test();
-		// Call the method under test
-		// $this->helper->checkview_clone_entry( $entry, $form );
-
-		// Assert that the entry was cloned and deleted
-		$this->assertTrue( $this->checkview_clone_gf_entry_called );
-		$this->assertTrue( $this->GFAPIDeleteEntry_called );
-
-		// Assert that the test was completed and sessions were cleared
-		$this->assertTrue( $this->complete_checkview_test_called );
-	}
-
-	private function mock_get_checkview_test_id( $return_value ) {
-		$this->checkview_test_id = $return_value;
-	}
-
-	private function mock_checkview_clone_gf_entry( $return_value ) {
-		$this->checkview_clone_gf_entry_called = true;
-		return $return_value;
-	}
-
-	private function mock_GFAPIDeleteEntry( $return_value ) {
-		$this->GFAPIDeleteEntry_called = true;
-		return $return_value;
-	}
-
-	private function mock_complete_checkview_test() {
-		$this->complete_checkview_test_called = true;
-		return true;
-	}
-
 	public function test_checkview_inject_email() {
 		$email = array( 'to' => 'original@example.com' );
 		$this->assertEquals( array( 'to' => TEST_EMAIL ), $this->helper->checkview_inject_email( $email ) );
@@ -120,35 +73,47 @@ class Test_Checkview_Gforms_Helper extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_checkview_disable_addons_feed() {
-		$feeds     = array( array( 'meta' => array( 'feed_condition_conditional_logic' => false ) ) );
-		$entry     = array( 'id' => rand( 1, 100 ) );
-		$form      = (object) array( 'id' => rand( 1, 100 ) );
-		$settings1 = array(
-			array(
-				'meta' => array(
-					'feed_condition_conditional_logic' => 1,
-					'feed_condition_conditional_logic_object' => array(
-						'conditionalLogic' => array(
-							'actionType' => 'show',
-							'logicType'  => 'all',
-							'rules'      => array(
-								array(
-									'fieldId'  => 1,
-									'operator' => 'is',
-									'value'    => 'Check Form Helper',
-								),
-							),
-						),
-					),
-				),
-			),
+	public function test_disable_addons_feed_no_test_id_returns_unchanged() {
+		$feeds  = array( array( 'id' => 1, 'addon_slug' => 'gravityformsmailchimp' ) );
+		$entry  = array( 'id' => rand( 1, 100 ) );
+		$form   = (object) array( 'id' => rand( 1, 100 ) );
+		$result = $this->helper->checkview_disable_addons_feed( $feeds, $entry, $form );
+		$this->assertSame( $feeds, $result );
+	}
+
+	public function test_disable_addons_feed_returns_empty_when_flag_set() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$feeds = array(
+			array( 'id' => 1, 'addon_slug' => 'gravityformsmailchimp' ),
+			array( 'id' => 2, 'addon_slug' => 'gravityformszapier' ),
 		);
-		
-		$this->assertEquals(
-			$settings1,
-			$this->helper->checkview_disable_addons_feed( $feeds, $entry, $form )
-		);
+		$entry = array( 'id' => rand( 1, 100 ) );
+		$form  = (object) array( 'id' => rand( 1, 100 ) );
+
+		$result = $this->helper->checkview_disable_addons_feed( $feeds, $entry, $form );
+		$this->assertSame( array(), $result );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_addons_feed_option_unset_returns_unchanged() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		delete_option( 'disable_actions_' . $test_id );
+
+		$feeds  = array( array( 'id' => 1, 'addon_slug' => 'gravityformsmailchimp' ) );
+		$entry  = array( 'id' => rand( 1, 100 ) );
+		$form   = (object) array( 'id' => rand( 1, 100 ) );
+		$result = $this->helper->checkview_disable_addons_feed( $feeds, $entry, $form );
+		$this->assertSame( $feeds, $result );
+
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
 	}
 
 	/**

--- a/tests/test-wpf.php
+++ b/tests/test-wpf.php
@@ -47,4 +47,220 @@ class TestCheckviewWpformsHelper extends WP_UnitTestCase {
 		$results = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}cv_entry WHERE form_id = {$form_data['id']}" );
 		$this->assertNotEmpty( $results );
 	}
+
+	public function test_disable_addons_action_registered() {
+		$this->assertEquals(
+			1,
+			has_action(
+				'wpforms_process',
+				array( $this->helper, 'checkview_wpforms_disable_addons' )
+			)
+		);
+	}
+
+	public function test_disable_addons_no_test_id_leaves_listeners_intact() {
+		$dummy = new stdClass();
+		add_action( 'wpforms_process_complete', array( $dummy, 'fake_listener' ), 5, 4 );
+
+		$this->helper->checkview_wpforms_disable_addons( array(), array(), array( 'id' => 7 ) );
+
+		$this->assertNotFalse(
+			has_action( 'wpforms_process_complete', array( $dummy, 'fake_listener' ) ),
+			'Third-party listener must remain when no test ID is set.'
+		);
+
+		remove_action( 'wpforms_process_complete', array( $dummy, 'fake_listener' ), 5 );
+	}
+
+	public function test_disable_addons_option_unset_leaves_listeners_intact() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		delete_option( 'disable_actions_' . $test_id );
+
+		$dummy = new stdClass();
+		add_action( 'wpforms_process_complete', array( $dummy, 'fake_listener' ), 5, 4 );
+
+		$this->helper->checkview_wpforms_disable_addons( array(), array(), array( 'id' => 7 ) );
+
+		$this->assertNotFalse(
+			has_action( 'wpforms_process_complete', array( $dummy, 'fake_listener' ) ),
+			'Third-party listener must remain when disable_actions option is unset.'
+		);
+
+		remove_action( 'wpforms_process_complete', array( $dummy, 'fake_listener' ), 5 );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_addons_removes_third_party_listeners_when_flag_set() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$mailchimp = new stdClass();
+		$webhook   = new stdClass();
+		$registration = new stdClass();
+		add_action( 'wpforms_process_complete', array( $mailchimp, 'process_entry' ), 5, 4 );
+		add_action( 'wpforms_process_complete', array( $webhook, 'send_payload' ), 10, 4 );
+		add_action( 'wpforms_process_complete', array( $registration, 'create_user' ), 15, 4 );
+
+		$this->helper->checkview_wpforms_disable_addons( array(), array(), array( 'id' => 7 ) );
+
+		$this->assertFalse(
+			has_action( 'wpforms_process_complete', array( $mailchimp, 'process_entry' ) ),
+			'Mailchimp-style provider listener must be removed.'
+		);
+		$this->assertFalse(
+			has_action( 'wpforms_process_complete', array( $webhook, 'send_payload' ) ),
+			'Webhook listener must be removed.'
+		);
+		$this->assertFalse(
+			has_action( 'wpforms_process_complete', array( $registration, 'create_user' ) ),
+			'User Registration listener must be removed.'
+		);
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_addons_whitelists_by_class_instance_not_priority() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		// Sanity: the constructor registers our cloning callback at priority 99.
+		$this->assertEquals(
+			99,
+			has_action(
+				'wpforms_process_complete',
+				array( $this->helper, 'checkview_log_wpform_test_entry' )
+			)
+		);
+
+		// Decoupling test: a non-helper callback AT the same priority 99 must
+		// still be removed, AND a helper callback at a non-99 priority must
+		// survive — proving the whitelist gates on instance, not priority.
+		$third_party_at_99 = new stdClass();
+		add_action( 'wpforms_process_complete', array( $third_party_at_99, 'fire' ), 99, 4 );
+
+		// Register the helper's own method at a different priority too.
+		add_action( 'wpforms_process_complete', array( $this->helper, 'checkview_log_wpform_test_entry' ), 50, 4 );
+
+		// And a low-priority third-party for completeness.
+		$third_party_at_5 = new stdClass();
+		add_action( 'wpforms_process_complete', array( $third_party_at_5, 'fire' ), 5, 4 );
+
+		$this->helper->checkview_wpforms_disable_addons( array(), array(), array( 'id' => 7 ) );
+
+		$this->assertEquals(
+			99,
+			has_action(
+				'wpforms_process_complete',
+				array( $this->helper, 'checkview_log_wpform_test_entry' )
+			),
+			'Own cloning callback at priority 99 must survive the purge.'
+		);
+		$this->assertNotFalse(
+			has_action( 'wpforms_process_complete', array( $this->helper, 'checkview_log_wpform_test_entry' ) ),
+			'Helper callback at priority 50 must also survive (whitelist by instance, not priority).'
+		);
+		$this->assertFalse(
+			has_action( 'wpforms_process_complete', array( $third_party_at_99, 'fire' ) ),
+			'Third-party listener at priority 99 must be removed despite sharing priority with helper.'
+		);
+		$this->assertFalse(
+			has_action( 'wpforms_process_complete', array( $third_party_at_5, 'fire' ) ),
+			'Third-party listener at priority 5 must be removed.'
+		);
+
+		// Clean up the manually-added priority-50 helper registration.
+		remove_action( 'wpforms_process_complete', array( $this->helper, 'checkview_log_wpform_test_entry' ), 50 );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_addons_removes_string_function_callback() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		// Plain string function name — `is_array($cb['function'])` is false,
+		// so the whitelist guard short-circuits to unset.
+		add_action( 'wpforms_process_complete', '__return_true', 10, 4 );
+
+		$this->helper->checkview_wpforms_disable_addons( array(), array(), array( 'id' => 7 ) );
+
+		$this->assertFalse(
+			has_action( 'wpforms_process_complete', '__return_true' ),
+			'Plain function-name callbacks must be removed.'
+		);
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_addons_removes_closure_callback() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$closure = function () {};
+		add_action( 'wpforms_process_complete', $closure, 10, 4 );
+
+		$this->helper->checkview_wpforms_disable_addons( array(), array(), array( 'id' => 7 ) );
+
+		$this->assertFalse(
+			has_action( 'wpforms_process_complete', $closure ),
+			'Closure callbacks must be removed.'
+		);
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_addons_removes_static_method_callback() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		// Static method form: ['ClassName', 'method'] — the [0] slot is a string,
+		// not an object, so `is_object` guard short-circuits to unset.
+		add_action( 'wpforms_process_complete', array( 'WP_Error', 'get_error_codes' ), 10, 4 );
+
+		$this->helper->checkview_wpforms_disable_addons( array(), array(), array( 'id' => 7 ) );
+
+		$this->assertFalse(
+			has_action( 'wpforms_process_complete', array( 'WP_Error', 'get_error_codes' ) ),
+			'Static-method-array callbacks must be removed.'
+		);
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_addons_clears_form_id_scoped_hook() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$dummy = new stdClass();
+		add_action( 'wpforms_process_complete_42', array( $dummy, 'fire' ), 10, 4 );
+
+		$this->helper->checkview_wpforms_disable_addons( array(), array(), array( 'id' => 42 ) );
+
+		$this->assertFalse(
+			has_action( 'wpforms_process_complete_42', array( $dummy, 'fire' ) ),
+			'Form-id-scoped variant must also be cleared.'
+		);
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
 }

--- a/tests/test-wsf.php
+++ b/tests/test-wsf.php
@@ -1,0 +1,88 @@
+<?php
+
+class Test_Checkview_WSF_Helper extends WP_UnitTestCase {
+
+	private $helper;
+
+	public function setUp(): void {
+		parent::setUp();
+		if ( is_plugin_active( 'ws-form/ws-form.php' ) || is_plugin_active( 'ws-form-pro/ws-form.php' ) ) {
+			require_once CHECKVIEW_INC_DIR . 'formhelpers/class-checkview-wsf-helper.php';
+		}
+		$this->helper = new Checkview_WSF_Helper();
+	}
+
+	public function test_construct() {
+		$this->assertInstanceOf( 'Checkview_WSF_Helper', $this->helper );
+		$this->assertInstanceOf( 'Checkview_Loader', $this->helper->loader );
+	}
+
+	public function test_disable_addons_feed_keeps_database_when_flag_set() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		// Pass $run=false to prove the allowlist FORCES true regardless of input.
+		$config = array( 'id' => 'database' );
+		$result = $this->helper->checkview_disable_addons_feed( false, null, null, null, false, $config );
+		$this->assertTrue( $result, 'Database action must run even when disable_actions is set and $run=false.' );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_addons_feed_keeps_message_when_flag_set() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$config = array( 'id' => 'message' );
+		$result = $this->helper->checkview_disable_addons_feed( false, null, null, null, false, $config );
+		$this->assertTrue( $result );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_addons_feed_keeps_email_when_flag_set() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$config = array( 'id' => 'email' );
+		$result = $this->helper->checkview_disable_addons_feed( false, null, null, null, false, $config );
+		$this->assertTrue( $result );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_addons_feed_blocks_third_party_when_flag_set() {
+		$test_id                         = 'aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee';
+		$_REQUEST['checkview_test_id']   = $test_id;
+		$_REQUEST['checkview_test_type'] = 'form';
+		update_option( 'disable_actions_' . $test_id, 'true', false );
+
+		$config = array( 'id' => 'mailchimp' );
+		$result = $this->helper->checkview_disable_addons_feed( true, null, null, null, false, $config );
+		$this->assertFalse( $result, 'Third-party action must be blocked when disable_actions is set.' );
+
+		delete_option( 'disable_actions_' . $test_id );
+		unset( $_REQUEST['checkview_test_id'], $_REQUEST['checkview_test_type'] );
+	}
+
+	public function test_disable_addons_feed_third_party_runs_without_flag() {
+		$config = array( 'id' => 'mailchimp' );
+		$result = $this->helper->checkview_disable_addons_feed( true, null, null, null, false, $config );
+		$this->assertTrue( $result, 'Third-party action passes through original $run when disable_actions is unset.' );
+	}
+
+	public function test_disable_addons_feed_passes_through_run_value() {
+		$config = array( 'id' => 'mailchimp' );
+		$result = $this->helper->checkview_disable_addons_feed( false, null, null, null, false, $config );
+		$this->assertFalse( $result, 'Original $run=false must be preserved when no override applies.' );
+	}
+}


### PR DESCRIPTION
## Summary
- WPForms helper never gated integration hooks on the per-test `disable_actions` flag, so Mailchimp, ActiveCampaign, User Registration, Post Submissions, Webhooks, and any custom code on `wpforms_process_complete` still fired during CheckView tests
- Every other form helper (CF7/FF/NF/GF/Formidable/WSF/Everest/Forminator) implemented `disable_actions` in PR #180 — WPForms was missed and only got the per-test scoping for `disable_email_receipt`
- Surfaced when a real test on a customer site at `https://app.checkview.io/.../test-flows/c236cf36-4da3-4e80-95d4-608ddd4f4577` (flow had `disable_actions: yes`, helper 2.0.33 deployed) still produced a Mailchimp subscriber

## Approach
Hooks `wpforms_process` at priority 1 (fires before `wpforms_process_complete` in `WPForms_Process::process()`) and walks `$wp_filter` to remove every callback on `wpforms_process_complete` + the form-id-scoped variant — except those bound to a `Checkview_Wpforms_Helper` instance. Whitelisting by class instance (not priority) survives any future priority change to the cloning callback.

Mirrors the everest-forms helper's blanket-removal pattern. Used here because WPForms has no centralized addon-skip filter (unlike GF's `gform_addon_pre_process_feeds`): different addons read config from different `$form_data` sub-keys (providers vs. settings.user_registration vs. settings.post_submissions), and custom user code reads nothing — the only chokepoint that catches all of them is the hook itself.

## Preserved
- **Native email notifications** fire via `WPForms_Process::process_emails()` (a direct call, not via this action) so `assert_email_received` still works
- **Entry save** into `wpforms_entries` happens earlier in `entry_save()` so the cloning callback at priority 99 still has an `entry_id` to read

## Tests
- `test-wpf.php`: 9 new tests covering action registration, no-test-id no-op, option-unset no-op, third-party removal, **whitelist-by-instance-not-priority** (with helper at non-99 priority + non-helper at 99 to decouple priority from instance), string/closure/static callback removal, form-id-scoped hook removal
- `test-gf.php`: 3 new `disable_actions` tests; **removed stale tests**: `test_checkview_disable_addons_feed` asserted output structure the method never produces; `test_checkview_clone_entry` had production call commented out (assertions only verified mock self-flags) plus 4 dead mock helpers
- `test-fdf.php`: 5 new `disable_actions` tests (3 keep-tests now run with flag set + non-default `$skip` to actually exercise the allowlist); removed 32-line dead-commented block
- `test-wsf.php`: new file, 6 tests (3 keep-tests use `$run=false` + flag set to prove allowlist forces `true` regardless of input)

## Test plan
- [ ] CI: PHPUnit suite passes
- [ ] Manual: rerun the originating flow on test → confirm no Mailchimp subscriber appears
- [ ] Manual: WPForms form configured with User Registration addon → no real WP user created during a CheckView test
- [ ] Manual: WPForms form configured with Webhooks → no webhook fires
- [ ] Regression: WPForms form WITHOUT `disable_actions` (or flag unset) → integrations fire normally
- [ ] Regression: `assert_email_received` still receives the confirmation email at `<test_run_id>@test-mail.checkview.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)