### PR TITLE
feat(helpers): add parity disable_actions log lines for GF, FF, Formidable, WSF

### DIFF
--- a/includes/formhelpers/class-checkview-fluent-forms-helper.php
+++ b/includes/formhelpers/class-checkview-fluent-forms-helper.php
@@ -414,6 +414,13 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 			// silent fallback to "all feeds fire" which would let real integrations run
 			// during automated tests.
 			$native_keys = array( 'notifications' );
+			$dropped     = array_diff_key( $notifications, array_flip( $native_keys ) );
+			foreach ( array_keys( $dropped ) as $key ) {
+				Checkview_Admin_Logs::add(
+					'ip-logs',
+					'Disabled FF action type [' . $key . '] for CheckView test.'
+				);
+			}
 			return array_intersect_key( $notifications, array_flip( $native_keys ) );
 		}
 

--- a/includes/formhelpers/class-checkview-formidable-helper.php
+++ b/includes/formhelpers/class-checkview-formidable-helper.php
@@ -572,6 +572,10 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 			}
 			$cv_test_id = get_checkview_test_id();
 			if ( $cv_test_id && 'true' == get_option( 'disable_actions_' . $cv_test_id, false ) ) {
+				Checkview_Admin_Logs::add(
+					'ip-logs',
+					'Disabled Formidable action type [' . ( $action->post_excerpt ?? 'unknown' ) . '] for CheckView test.'
+				);
 				return true;
 			}
 			return false;

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -468,6 +468,15 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		public function checkview_disable_addons_feed( $feeds, $entry, $form ) {
 			$cv_test_id = get_checkview_test_id();
 			if ( $cv_test_id && 'true' == get_option( 'disable_actions_' . $cv_test_id, false ) ) {
+				if ( is_array( $feeds ) ) {
+					foreach ( $feeds as $feed ) {
+						$slug = isset( $feed['addon_slug'] ) ? $feed['addon_slug'] : ( isset( $feed['form_id'] ) ? 'feed_id_' . ( $feed['id'] ?? '?' ) : 'unknown' );
+						Checkview_Admin_Logs::add(
+							'ip-logs',
+							'Disabled GF addon feed [' . $slug . '] for CheckView test.'
+						);
+					}
+				}
 				return array();
 			}
 			return $feeds;

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -470,7 +470,16 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 			if ( $cv_test_id && 'true' == get_option( 'disable_actions_' . $cv_test_id, false ) ) {
 				if ( is_array( $feeds ) ) {
 					foreach ( $feeds as $feed ) {
-						$slug = isset( $feed['addon_slug'] ) ? $feed['addon_slug'] : ( isset( $feed['form_id'] ) ? 'feed_id_' . ( $feed['id'] ?? '?' ) : 'unknown' );
+						if ( ! is_array( $feed ) ) {
+							continue;
+						}
+						if ( isset( $feed['addon_slug'] ) ) {
+							$slug = $feed['addon_slug'];
+						} elseif ( isset( $feed['id'] ) ) {
+							$slug = 'feed_id_' . $feed['id'];
+						} else {
+							$slug = 'unknown';
+						}
 						Checkview_Admin_Logs::add(
 							'ip-logs',
 							'Disabled GF addon feed [' . $slug . '] for CheckView test.'

--- a/includes/formhelpers/class-checkview-wsf-helper.php
+++ b/includes/formhelpers/class-checkview-wsf-helper.php
@@ -309,6 +309,10 @@ if ( ! class_exists( 'Checkview_WSF_Helper' ) ) {
 			}
 			$cv_test_id = get_checkview_test_id();
 			if ( $cv_test_id && 'true' == get_option( 'disable_actions_' . $cv_test_id, false ) ) {
+				Checkview_Admin_Logs::add(
+					'ip-logs',
+					'Disabled WSF action type [' . ( $config['id'] ?? 'unknown' ) . '] for CheckView test.'
+				);
 				return false;
 			}
 			return $run;


### PR DESCRIPTION
## Summary
- Ninja Forms' helper logs each suppressed action type during CheckView tests (e.g. `Disabled NF action type [mailchimp] for CheckView test.`), making post-mortem audits trivially self-evidencing
- The 4 sibling helpers (GF, FF, Formidable, WSF) honored the disable_actions flag silently, so a forensic check across multiple sites required reading the helper source to confirm suppression actually fired
- This PR adds matching log lines on the disable branch of each helper

## Context
Surfaced when verifying PR #201's WPForms fix end-to-end across 6 prod InstaWP sites. Of the 5 form plugins with working disable_actions logic, only Ninja Forms left a clear log trail. Spot-checking the others required either source-code dive or addon-dashboard inspection per site. Adding parity log lines closes that gap.

## Changes
- **gforms**: per-feed log, includes `addon_slug` (e.g. `gravityformsmailchimp`) when available, falls back to `feed_id_<id>` then `unknown`
- **fluent**: per-dropped key (`slack`, `mailchimp_feeds`, `webhook`, `zapier`, etc.)
- **formidable**: per-action, uses `post_excerpt` (e.g. `mailchimp`, `register`)
- **wsf**: per-action, uses `config['id']` (e.g. `mailchimp`, `webhook`)

No behavioral change — log-only.

## After this PR
A future "did disable_actions actually unhook the addons" audit can be answered with a single grep (`grep -E 'Disabled (NF|GF|FF|Formidable|WSF) (action type|addon feed) \[' ip-logs-log-*.log`) instead of source dives or per-site dashboard inspection.

## Commits
- `6a857a8` initial 4-helper parity log change
- `3040d16` follow-up: fix conditional bug in GF slug fallback + add `is_array($feed)` guard

## Test plan
- [ ] CI: PHPUnit suite passes (no test changes — pure log additions)
- [ ] Manual: run a CheckView test on a form with Mailchimp/Zapier/etc. configured on each of GF/FF/Formidable/WSF — verify `Disabled <X>` lines appear in `wp-content/uploads/checkview-logs/ip-logs-log-YYYY-MM-DD.log`
- [ ] Regression: run a test WITHOUT disable_actions set — verify no spurious `Disabled` lines appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)