### PR TITLE
fix(formidable): guard non-array radio options to prevent fatal

### DIFF
--- a/includes/formhelpers/class-checkview-formidable-helper.php
+++ b/includes/formhelpers/class-checkview-formidable-helper.php
@@ -484,8 +484,14 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 							break;
 						case 'radio':
 							$field_options = maybe_unserialize( $field->options );
-							foreach ( $field_options as $key => $val ) {
-								$field_options[ $key ]['field_id'] = $field_id . '-' . $key;
+							if ( is_array( $field_options ) ) {
+								foreach ( $field_options as $key => $val ) {
+									if ( is_array( $val ) ) {
+										$field_options[ $key ]['field_id'] = $field_id . '-' . $key;
+									} else {
+										error_log( "Non-array value detected in field_options for field '{$field_id}', key '{$key}': " . print_r( $val, true ) );
+									}
+								}
 							}
 							$fields[ $field->id ] = array(
 								'type'     => $field->type,
@@ -500,12 +506,13 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 							break;
 						case 'checkbox':
 							$field_options = maybe_unserialize( $field->options );
-							foreach ( $field_options as $key => $val ) {
-								// Ensure the current value is an array.
-								if ( is_array( $val ) ) {
-									$field_options[ $key ]['field_id'] = $field_id . '-' . $key;
-								} else {
-									error_log( "Non-array value detected in field_options for key '{$field_id }': " . print_r( $val, true ) );
+							if ( is_array( $field_options ) ) {
+								foreach ( $field_options as $key => $val ) {
+									if ( is_array( $val ) ) {
+										$field_options[ $key ]['field_id'] = $field_id . '-' . $key;
+									} else {
+										error_log( "Non-array value detected in field_options for field '{$field_id}', key '{$key}': " . print_r( $val, true ) );
+									}
 								}
 							}
 							$fields[ $field->id ] = array(


### PR DESCRIPTION
## Summary
- Adds the `is_array($val)` guard to the `radio` case in `Checkview_Formidable_Helper::get_form_fields()` (the checkbox case already had it as of Jan 2025; radio was missed).
- Adds an outer `is_array($field_options)` guard to both `radio` and `checkbox` so a non-array `maybe_unserialize()` result no longer warns/crashes on `foreach`.
- Tightens the existing `error_log` message: now includes both `field_id` and `key` (was labeling `field_id` as "key" and had a stray trailing space).

## Bug
Customer site **authorimprints.com** crashed with:
```
PHP Fatal error: Uncaught TypeError: Cannot access offset of type string on string
  in class-checkview-formidable-helper.php:488
```
Triggered by a Formidable radio field where one option was stored as the bare string `"Other"` instead of an array. The fatal aborted the `frm_after_create_entry` action chain, skipped the `cv_entry_meta` insert, and left the CheckView test stuck.

## Why this case
Formidable allows admins to author radio options as either an array (`['label' => 'Yes']`) or a plain string. The plugin only handled the array shape.

## Test plan
- [ ] Build a Formidable form with a radio field that has at least one bare-string option (e.g., add `Other` via the "Show Other option" toggle).
- [ ] Trigger a CheckView test against that form on the test environment.
- [ ] Confirm the test completes and `cv_entry_meta` rows are written (no PHP fatal in `error_log`).
- [ ] Verify the existing checkbox path still works (regression check — same guard pattern was unified there too).

## Reviewed
Multi-angle review (logical / security / fragility / standards / downstream) all clean. `'choices'` key is written but never read in the repo, so mixed-shape entries are harmless. No other form helper has the same anti-pattern (others use API objects, not `maybe_unserialize` on raw DB rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)