### PR TITLE
fix(form-helpers): truncate source_url to 200 chars before cv_entry insert

### DIFF
--- a/includes/formhelpers/class-checkview-cf7-helper.php
+++ b/includes/formhelpers/class-checkview-cf7-helper.php
@@ -354,7 +354,7 @@ if ( ! class_exists( 'Checkview_Cf7_Helper' ) ) {
 				$entry_data  = array(
 					'form_id' => $form_id,
 					'status' => 'publish',
-					'source_url' => isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '',
+					'source_url' => isset( $_SERVER['HTTP_REFERER'] ) ? substr( sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ), 0, 200 ) : '',
 					'date_created' => current_time( 'mysql' ),
 					'date_updated' => current_time( 'mysql' ),
 					'uid' => $checkview_test_id,

--- a/includes/formhelpers/class-checkview-everest-forms-helper.php
+++ b/includes/formhelpers/class-checkview-everest-forms-helper.php
@@ -250,7 +250,7 @@ if ( ! class_exists( 'Checkview_Everest_Forms_Helper' ) ) {
 			$entry_data  = array(
 				'form_id'      => $form_id,
 				'status'       => 'publish',
-				'source_url'   => isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '',
+				'source_url'   => isset( $_SERVER['HTTP_REFERER'] ) ? substr( sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ), 0, 200 ) : '',
 				'date_created' => current_time( 'mysql' ),
 				'date_updated' => current_time( 'mysql' ),
 				'uid'          => $checkview_test_id,

--- a/includes/formhelpers/class-checkview-fluent-forms-helper.php
+++ b/includes/formhelpers/class-checkview-fluent-forms-helper.php
@@ -334,7 +334,7 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 				'uid' => $checkview_test_id,
 				'form_type' => 'FluentForms',
 				'form_id' => $form_id,
-				'source_url' => isset( $row['source_url'] ) ? $row['source_url'] : 'n/a',
+				'source_url' => isset( $row['source_url'] ) ? substr( $row['source_url'], 0, 200 ) : 'n/a',
 				'response' => isset( $row['response'] ) ? $row['response'] : 'n/a',
 				'user_agent' => isset( $row['browser'] ) ? $row['browser'] : 'n/a',
 				'ip' => isset( $row['ip'] ) ? $row['ip'] : 'n/a',

--- a/includes/formhelpers/class-checkview-formidable-helper.php
+++ b/includes/formhelpers/class-checkview-formidable-helper.php
@@ -193,7 +193,7 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 			$entry_data = array(
 				'form_id' => $form_id,
 				'status' => 'publish',
-				'source_url' => isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '',
+				'source_url' => isset( $_SERVER['HTTP_REFERER'] ) ? substr( sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ), 0, 200 ) : '',
 				'date_created' => current_time( 'mysql' ),
 				'date_updated' => current_time( 'mysql' ),
 				'uid' => $checkview_test_id,

--- a/includes/formhelpers/class-checkview-forminator-helper.php
+++ b/includes/formhelpers/class-checkview-forminator-helper.php
@@ -178,7 +178,7 @@ if ( ! class_exists( 'Checkview_Forminator_Helper' ) ) {
 			$entry_data = array(
 				'form_id'      => $form_id,
 				'status'       => 'publish',
-				'source_url'   => isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '',
+				'source_url'   => isset( $_SERVER['HTTP_REFERER'] ) ? substr( sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ), 0, 200 ) : '',
 				'date_created' => current_time( 'mysql' ),
 				'date_updated' => current_time( 'mysql' ),
 				'uid'          => $checkview_test_id,

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -443,6 +443,9 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 			$entry_table = $wpdb->prefix . 'cv_entry';
 			$row['uid'] = $uid;
 			$row['form_type'] = 'GravityForms';
+			if ( isset( $row['source_url'] ) ) {
+				$row['source_url'] = substr( $row['source_url'], 0, 200 );
+			}
 			$result = $wpdb->insert( $entry_table, $row );
 
 			if ( ! $result ) {

--- a/includes/formhelpers/class-checkview-ninja-forms-helper.php
+++ b/includes/formhelpers/class-checkview-ninja-forms-helper.php
@@ -184,7 +184,7 @@ if ( ! class_exists( 'Checkview_Ninja_Forms_Helper' ) ) {
 			$entry_data  = array(
 				'form_id' => $form_id,
 				'status' => 'publish',
-				'source_url' => isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '',
+				'source_url' => isset( $_SERVER['HTTP_REFERER'] ) ? substr( sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ), 0, 200 ) : '',
 				'date_created' => current_time( 'mysql' ),
 				'date_updated' => current_time( 'mysql' ),
 				'uid' => $checkview_test_id,

--- a/includes/formhelpers/class-checkview-wpforms-helper.php
+++ b/includes/formhelpers/class-checkview-wpforms-helper.php
@@ -317,7 +317,7 @@ if ( ! class_exists( 'Checkview_Wpforms_Helper' ) ) {
 			$entry_data  = array(
 				'form_id' => $form_id,
 				'status' => 'publish',
-				'source_url' => isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '',
+				'source_url' => isset( $_SERVER['HTTP_REFERER'] ) ? substr( sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ), 0, 200 ) : '',
 				'date_created' => current_time( 'mysql' ),
 				'date_updated' => current_time( 'mysql' ),
 				'uid' => $checkview_test_id,

--- a/includes/formhelpers/class-checkview-wsf-helper.php
+++ b/includes/formhelpers/class-checkview-wsf-helper.php
@@ -203,7 +203,7 @@ if ( ! class_exists( 'Checkview_WSF_Helper' ) ) {
 			$entry_data  = array(
 				'form_id' => $form_id,
 				'status' => 'publish',
-				'source_url' => isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '',
+				'source_url' => isset( $_SERVER['HTTP_REFERER'] ) ? substr( sanitize_url( wp_unslash( $_SERVER['HTTP_REFERER'] ) ), 0, 200 ) : '',
 				'date_created' => current_time( 'mysql' ),
 				'date_updated' => current_time( 'mysql' ),
 				'uid' => $checkview_test_id,


### PR DESCRIPTION
## Summary

Fixes a silent fleet-wide bug where `$wpdb->insert(cv_entry, ...)` rejects rows whose `source_url` exceeds the column's varchar(200) limit. WordPress's `wpdb::process_field_lengths()` pre-flight check returns false with:

```
Processing the value for the following field failed: source_url.
The supplied value may be too long or contains invalid data.
```

…and the helper logs only the generic "Failed to clone submission entry data." (no `$wpdb->last_error`), so the failure has been invisible — surfacing only as downstream "submission-not-found" test failures with no diagnostic trail.

## Why we hit it

CheckView's test framework appends ~125 chars of query string to the page URL:
`?checkview_test_id=<uuid-36>&checkview_test_type=form&disable_actions=true&disable_webhooks=true`

That leaves only ~75 chars for `https://<domain>/<page-slug>/` before the column overflows. Any descriptive page slug on a normal domain blows it. Confirmed on cf7dates.instawp.xyz where slug `date-default-starting-next-friday-and-ending-the-1st` (54 chars) pushed the referer to **221 chars** and broke every test on that flow for 5+ weeks (first failure: 2026-05-15).

## Fix

Truncate `source_url` to 200 chars at every `cv_entry` insert site. 9 form helpers covered:
- 7 helpers (cf7, everest, formidable, forminator, ninja, wpforms, wsf) wrap `sanitize_url(HTTP_REFERER)` in `substr(..., 0, 200)`
- Fluent Forms truncates `$row['source_url']`
- Gravity Forms truncates `$row['source_url']` in its wholesale `gf_entry` → `cv_entry` copy

Not a CF7 6.1.6 regression — bug has existed since the column was sized at varchar(200). cf7dates just surfaced it because its slug pushed the URL over the limit.

## Diagnostic process

Helper plugin doesn't log `$wpdb->last_error` on insert failures, so we directly edited `class-checkview-cf7-helper.php` on cf7dates via WP admin Plugin Editor to add error capture, re-ran the failing test, captured the exact MySQL error, then reverted the edit. Full diagnostic log captured the failing `entry_data` payload showing the 221-char source_url.

## Review

Reviewed via 5 independent angles (correctness, security, coverage, fragility, downstream consumers). No defects in the fix. Adjacent latent issues flagged for follow-up:
- Gravity Forms also copies `transaction_id`/`payment_method`/`payment_status`/`currency` from `gf_entry` — dormant until a GF Stripe/PayPal form is tested
- Fluent Forms passes `$row['browser']` to `cv_entry.user_agent` (varchar 250) unguarded — modern Chrome UAs can overflow
- Helper still doesn't log `$wpdb->last_error` — should add for future diagnostic speed
- No long-URL test fixture exists — should add to prevent regression

These will land in a stacked follow-up PR.

## Test plan

- [ ] Merge to development → auto-deploys to quality channel (InstaWP test sites + Pressable `checkview-qa` tag)
- [ ] Re-run cf7dates Date Default flow `30ead368-cc52-4a4c-99e6-aef0678be1a4` — should pass `assert_form_submitted`
- [ ] Spot-check 1-2 successfully-running customer flows to confirm no regression
- [ ] After verification on quality, promote to main for next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)