### PR TITLE
fix(form-helpers): cv_entry write hardening — limit map, last_error logs, meta_key truncate

### DIFF
--- a/includes/checkview-functions.php
+++ b/includes/checkview-functions.php
@@ -1496,3 +1496,62 @@ if ( ! function_exists( 'cv_delete_option' ) ) {
 		return true;
 	}
 }
+
+if ( ! function_exists( 'checkview_get_cv_entry_string_limits' ) ) {
+	/**
+	 * Returns the cv_entry string-column max-length map.
+	 *
+	 * Single source of truth mirroring the schema declared in
+	 * Checkview_Activator::checkview_run_sql(). When the schema widens or
+	 * narrows a varchar, update both places.
+	 *
+	 * Columns intentionally omitted:
+	 *   - uid varchar(255): generated internally (UUID, ~36 chars).
+	 *   - response longtext: no varchar limit.
+	 *   - meta_key/meta_value: belong to cv_entry_meta, not cv_entry.
+	 *
+	 * @return array<string,int> Column name => max char length.
+	 */
+	function checkview_get_cv_entry_string_limits() {
+		return array(
+			'ip'             => 45,
+			'source_url'     => 200,
+			'user_agent'     => 250,
+			'currency'       => 5,
+			'payment_status' => 15,
+			'payment_method' => 30,
+			'transaction_id' => 50,
+			'status'         => 20,
+			'form_type'      => 20,
+		);
+	}
+}
+
+if ( ! function_exists( 'checkview_truncate_for_cv_entry' ) ) {
+	/**
+	 * Truncates string fields of a cv_entry-bound row to the schema's
+	 * varchar limits.
+	 *
+	 * WordPress's wpdb::process_field_lengths() rejects inserts whose
+	 * string values exceed the destination column's declared length,
+	 * returning false from wpdb::insert() with last_error set to
+	 * "Processing the value for the following field failed: <col>. The
+	 * supplied value may be too long or contains invalid data." This
+	 * helper pre-truncates so the insert succeeds and the prefix is
+	 * preserved.
+	 *
+	 * Only mutates keys present in checkview_get_cv_entry_string_limits()
+	 * and only when the value is a string. Other keys pass through.
+	 *
+	 * @param array $row Associative row about to be passed to wpdb::insert.
+	 * @return array Row with overflowing string fields truncated.
+	 */
+	function checkview_truncate_for_cv_entry( array $row ) {
+		foreach ( checkview_get_cv_entry_string_limits() as $col => $max ) {
+			if ( isset( $row[ $col ] ) && is_string( $row[ $col ] ) ) {
+				$row[ $col ] = substr( $row[ $col ], 0, $max );
+			}
+		}
+		return $row;
+	}
+}

--- a/includes/formhelpers/class-checkview-cf7-helper.php
+++ b/includes/formhelpers/class-checkview-cf7-helper.php
@@ -365,7 +365,7 @@ if ( ! class_exists( 'Checkview_Cf7_Helper' ) ) {
 				$result = $wpdb->insert( $entry_table, $entry_data );
 
 				if ( ! $result ) {
-					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data.' );
+					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 				} else {
 					Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry data (inserted ' . (int) $result . ' rows into ' . $entry_table . ').' );
 				}
@@ -375,11 +375,16 @@ if ( ! class_exists( 'Checkview_Cf7_Helper' ) ) {
 				$count = 0;
 
 				foreach ( $form_data as $key => $val ) {
+					// CF7 field `name` attributes are raw POST keys, not
+					// constrained to any length by CF7 itself. cv_entry_meta.meta_key
+					// is varchar(255), so an unusually long form-field name would
+					// otherwise overflow and fail wpdb::process_field_lengths().
+					$meta_key = is_string( $key ) ? substr( $key, 0, 255 ) : $key;
 					$entry_metadata = array(
 						'uid' => $checkview_test_id,
 						'form_id' => $form_id,
 						'entry_id' => $inserted_entry_id,
-						'meta_key' => $key,
+						'meta_key' => $meta_key,
 						'meta_value' => $val,
 					);
 
@@ -394,7 +399,7 @@ if ( ! class_exists( 'Checkview_Cf7_Helper' ) ) {
 					Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry meta data (inserted ' . $count . ' rows into ' . $entry_meta_table . ').' );
 				} else {
 					if ( count( $form_data ) > 0 ) {
-						Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data.' );
+						Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 					}
 				}
 

--- a/includes/formhelpers/class-checkview-everest-forms-helper.php
+++ b/includes/formhelpers/class-checkview-everest-forms-helper.php
@@ -261,7 +261,7 @@ if ( ! class_exists( 'Checkview_Everest_Forms_Helper' ) ) {
 			$result = $wpdb->insert( $entry_table, $entry_data );
 
 			if ( ! $result ) {
-				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data.' );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 			} else {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry data (inserted ' . (int) $result . ' rows into ' . $entry_table . ').' );
 			}
@@ -297,7 +297,7 @@ if ( ! class_exists( 'Checkview_Everest_Forms_Helper' ) ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry meta data (inserted ' . $count . ' rows into ' . $entry_meta_table . ').' );
 			} else {
 				if ( count( $fields ) > 0 ) {
-					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data.' );
+					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 				}
 			}
 

--- a/includes/formhelpers/class-checkview-fluent-forms-helper.php
+++ b/includes/formhelpers/class-checkview-fluent-forms-helper.php
@@ -323,7 +323,7 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry meta data (inserted ' . $count . ' rows into ' . $entry_meta_table . ').' );
 			} else {
 				if ( count( $rows ) > 0 ) {
-					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data.' );
+					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 				}
 			}
 
@@ -345,10 +345,16 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 				'payment_amount' => isset( $row['payment_total'] ) ? $row['payment_total'] : 0,
 			);
 
+			// Fluent's user_agent (passed-through $row['browser']) and
+			// payment_method / payment_status fields can exceed cv_entry's
+			// limits. checkview_truncate_for_cv_entry() applies the schema's
+			// varchar caps to every applicable column.
+			$data = checkview_truncate_for_cv_entry( $data );
+
 			$result = $wpdb->insert( $entry_table, $data );
 
 			if ( ! $result ) {
-				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data.' );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 			} else {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry data (inserted ' . (int) $result . ' rows into ' . $entry_table . ').' );
 			}

--- a/includes/formhelpers/class-checkview-formidable-helper.php
+++ b/includes/formhelpers/class-checkview-formidable-helper.php
@@ -204,7 +204,7 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 			$result  = $wpdb->insert( $entry_table, $entry_data );
 
 			if ( ! $result ) {
-				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data.' );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 			} else {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry data (inserted ' . (int) $result . ' rows into ' . $entry_table . ').' );
 			}
@@ -407,7 +407,7 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry meta data (inserted ' . $count . ' rows into ' . $entry_meta_table . ').' );
 			} else {
 				if ( count( $form_fields ) > 0 ) {
-					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data.' );
+					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 				}
 			}
 

--- a/includes/formhelpers/class-checkview-forminator-helper.php
+++ b/includes/formhelpers/class-checkview-forminator-helper.php
@@ -189,7 +189,7 @@ if ( ! class_exists( 'Checkview_Forminator_Helper' ) ) {
 			$result = $wpdb->insert( $entry_table, $entry_data );
 
 			if ( ! $result ) {
-				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data.' );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 			} else {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry data (inserted ' . (int) $result . ' rows into ' . $entry_table . ').' );
 			}
@@ -223,7 +223,7 @@ if ( ! class_exists( 'Checkview_Forminator_Helper' ) ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry meta data (inserted ' . $count . ' rows into ' . $entry_meta_table . ').' );
 			} else {
 				if ( count( $form_fields ) > 0 ) {
-					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data.' );
+					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 				}
 			}
 

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -430,7 +430,7 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry meta data (inserted ' . $count . ' rows into ' . $entry_meta_table . ').' );
 			} else {
 				if ( count( $rows ) > 0 ) {
-					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data.' );
+					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 				}
 			}
 
@@ -443,10 +443,17 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 			$entry_table = $wpdb->prefix . 'cv_entry';
 			$row['uid'] = $uid;
 			$row['form_type'] = 'GravityForms';
+
+			// gf_entry's varchars are wider than cv_entry's (e.g.,
+			// transaction_id 255 vs 50, payment_method 255 vs 30) so a
+			// wholesale row copy can hit wpdb::process_field_lengths()
+			// rejection on payment forms.
+			$row = checkview_truncate_for_cv_entry( $row );
+
 			$result = $wpdb->insert( $entry_table, $row );
 
 			if ( ! $result ) {
-				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data.' );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 			} else {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry data (inserted ' . (int) $result . ' rows into ' . $entry_table . ').' );
 			}

--- a/includes/formhelpers/class-checkview-ninja-forms-helper.php
+++ b/includes/formhelpers/class-checkview-ninja-forms-helper.php
@@ -195,7 +195,7 @@ if ( ! class_exists( 'Checkview_Ninja_Forms_Helper' ) ) {
 			$result = $wpdb->insert( $entry_table, $entry_data );
 
 			if ( ! $result ) {
-				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data.' );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 			} else {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry data (inserted ' . (int) $result . ' rows into ' . $entry_table . ').' );
 			}
@@ -272,7 +272,7 @@ if ( ! class_exists( 'Checkview_Ninja_Forms_Helper' ) ) {
 			if ( $count > 0 ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry meta data (inserted ' . $count . ' rows into ' . $entry_meta_table . ').' );
 			} else {
-				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data.' );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 			}
 
 			if ( $entry_id > 0 ) {

--- a/includes/formhelpers/class-checkview-wpforms-helper.php
+++ b/includes/formhelpers/class-checkview-wpforms-helper.php
@@ -328,7 +328,7 @@ if ( ! class_exists( 'Checkview_Wpforms_Helper' ) ) {
 			$result = $wpdb->insert( $entry_table, $entry_data );
 
 			if ( ! $result ) {
-				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data.' );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 			} else {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry data (inserted ' . (int) $result . ' rows into ' . $entry_table . ').' );
 			}
@@ -468,7 +468,7 @@ if ( ! class_exists( 'Checkview_Wpforms_Helper' ) ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry meta data (inserted ' . $count . ' rows into ' . $entry_meta_table . ').' );
 			} else {
 				if ( count( $form_fields ) > 0 ) {
-					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data.' );
+					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 				}
 			}
 

--- a/includes/formhelpers/class-checkview-wsf-helper.php
+++ b/includes/formhelpers/class-checkview-wsf-helper.php
@@ -214,7 +214,7 @@ if ( ! class_exists( 'Checkview_WSF_Helper' ) ) {
 			$result = $wpdb->insert( $entry_table, $entry_data );
 
 			if ( ! $result ) {
-				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data.' );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 			} else {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry data (inserted ' . (int) $result . ' rows into ' . $entry_table . ').' );
 			}
@@ -247,7 +247,7 @@ if ( ! class_exists( 'Checkview_WSF_Helper' ) ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry meta data (inserted ' . $count . ' rows into ' . $entry_meta_table . ').' );
 			} else {
 				if ( count( $form_fields ) > 0 ) {
-					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data.' );
+					Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 				}
 			}
 


### PR DESCRIPTION
## Summary

Stacked follow-up to PR #205. #205 fixes one column (`source_url`) that has been silently rejecting cv_entry inserts across the fleet for 5+ weeks. This PR closes the adjacent gaps surfaced during review of #205:

- **Single-source limit map** in `checkview-functions.php` for every overflow-prone `cv_entry` varchar column
- **Gravity Forms wholesale row copy** now runs through the new helper — addresses `transaction_id` (255 → 50), `payment_method` (255 → 30), `payment_status` (200 → 15), `currency` (15 → 5), `user_agent` (250 → 250), etc.
- **Fluent Forms wholesale-style payload** — same helper applied; covers `user_agent` (Chrome UAs with client-hints routinely > 250 chars) and Fluent's payment fields
- **`$wpdb->last_error` logging in all 18 insert-failure log lines** across 9 helpers. This is the diagnostic gap that kept the source_url bug invisible for 5+ weeks — every "Failed to clone submission entry [data|meta data]." now carries MySQL error context
- **CF7 `meta_key` truncate to 255** — the one helper where `meta_key` comes from raw POST keys (unbounded user input flowing into `cv_entry_meta.meta_key varchar(255)`)

10 files / +97 / -20. No new tests in this PR (intentional — the testing approach needs its own discussion).

## Stacking with PR #205

Branched from `development`. The 7 narrow helpers (cf7/everest/formidable/forminator/ninja/wpforms/wsf) only change their failure-log lines — far enough from #205's `source_url` edits that git resolves cleanly.

**The Gravity Forms helper is the one real conflict.** #205 adds a 3-line `isset / substr / source_url` block at `gforms-helper.php` line ~446. This PR replaces that same area with a single `\$row = checkview_truncate_for_cv_entry( \$row );` call, which truncates `source_url` AND every other overflow-prone `gf_entry` column. Functionally a superset. **When resolving the conflict: keep this PR's single function call, drop #205's 3-line inline block.** No behavior is lost.

## Review

5-angle review (correctness / security / coverage / fragility / cross-helper consistency). No critical defects. Outstanding items being tracked as separate follow-up PRs (Fluent `meta_key` overflow, log CRLF sanitization, orphan-meta-row cleanup).

## Test plan

- [ ] Merge to `development` → auto-deploys to quality channel (InstaWP test sites + Pressable `checkview-qa` tag)
- [ ] Re-run cf7dates Date Default flow `30ead368-cc52-4a4c-99e6-aef0678be1a4` → should still pass (regression check)
- [ ] Spot-check a GF flow and a Fluent flow to confirm cv_entry inserts still succeed
- [ ] Inspect `ip-logs` after the next intentional failure for the new `wpdb->last_error=[...]` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)