### PR TITLE
fix(woo): scope order.deleted transient to its own topic — restore toggle-OFF webhook delivery

### DIFF
--- a/includes/woocommercehelper/class-checkview-woo-automated-testing.php
+++ b/includes/woocommercehelper/class-checkview-woo-automated-testing.php
@@ -860,7 +860,17 @@ class Checkview_Woo_Automated_Testing {
 			// the deletion was driven by us and should be suppressed
 			// downstream (TTL covers WC's webhook-retry backoff which can
 			// extend to multiple days on a failing endpoint).
-			if ( ! $order ) {
+			//
+			// CRITICAL: scope this to the `order.deleted` topic specifically.
+			// Other order.* topics (created/updated) can also have `! $order`
+			// at AS-delivery time — e.g. when the SaaS-side
+			// `/store/deleteorders` REST call wipes the order between WC
+			// enqueueing `order.created` and AS dequeueing it. For toggle-OFF
+			// tests we WANT those deliveries to attempt (WC will build a 404
+			// payload, but at minimum Shippo's webhook receiver sees the
+			// event fire). Suppressing them here silenced legitimate
+			// toggle-OFF deliveries — a regression vs pre-PR baseline.
+			if ( ! $order && 'order.deleted' === $topic ) {
 				if ( get_transient( 'cv_deleted_test_order_' . (int) $arg ) ) {
 					return false;
 				}


### PR DESCRIPTION
## Summary

Tightens a one-line conjunct in `checkview_filter_webhooks` so the `cv_deleted_test_order_<id>` transient check only applies to the `order.deleted` topic. Restores baseline `order.created` delivery behavior for toggle-OFF tests on InstaWP / nicholaslodge.

## Why

Surfaced post-merge of #207. Customer report on nicholaslodge.com test run [4eea1eb0](https://app.checkview.io/organizations/f686c5cb-5512-4fcb-a03b-48248498abd7/tests/4eea1eb0-3692-4f3c-a0d3-fcc5b81f5eb5): with the "Disable Form Integrations" toggle OFF, Mailchimp received the test customer (expected — captured sync at checkout) but Shippo received NOTHING (unexpected — expected at least an attempt).

Root cause: PR #207 commit 4 added the transient set/get pair to suppress the `order.deleted` cleanup webhook for toggle-ON tests. The intent was good but the filter's check was too broad — it matched ANY `order.*` topic when `wc_get_order` returned false. The SaaS-side `/store/deleteorders` REST call wipes the order between WC enqueueing `order.created` and AS dequeueing it; on dequeue `wc_get_order` returns false, the over-broad transient check triggers, the legitimate `order.created` delivery is suppressed.

Before #207: Shippo would receive a 404-body webhook (annoying but visible).
After #207: Shippo receives nothing (regression).
After this fix: 404-body webhook returns (baseline). Full real-payload delivery for toggle-OFF still requires SaaS-side ClickUp [868jnwz79](https://app.clickup.com/t/868jnwz79) — defer `/store/deleteorders` so AS finishes first.

## What's in it

One commit. One-line code change (`! $order` → `! $order && 'order.deleted' === $topic`) plus 9 lines of inline comment explaining the regression so future maintainers don't broaden it again.

```diff
-			if ( ! $order ) {
+			if ( ! $order && 'order.deleted' === $topic ) {
 				if ( get_transient( 'cv_deleted_test_order_' . (int) $arg ) ) {
 					return false;
 				}
 			}
```

## Behavior matrix

| Scenario | Topic | Order at delivery | Pre-#207 | #207 (current bug) | This fix |
|---|---|---|---|---|---|
| Toggle ON test | `order.created` | exists | Suppressed (sync filter) | Same — never enqueued | Same |
| Toggle ON test | `order.deleted` at cleanup | gone | 404 to Shippo (unwanted) | Suppressed (transient) | Suppressed ✓ |
| Toggle OFF test | `order.created` | gone (SaaS race) | 404 payload to Shippo | **Suppressed (regression)** | 404 payload to Shippo (baseline restored) |
| Toggle OFF test | `order.deleted` at cleanup | gone | 404 to Shippo | Suppressed (transient) | Suppressed (debatable; see below) |

## Toggle-OFF `order.deleted` decision (open question)

Currently the transient is SET in `checkview_delete_orders` regardless of toggle state. That means even on toggle-OFF tests, the `order.deleted` cleanup webhook is suppressed by this fix.

Reviewers split on this: 4 of 5 lenses said ship as-is; 1 of 5 argued for the stronger fix (scope the transient SET to toggle-ON tests too, so toggle-OFF `order.deleted` would also deliver). The practical impact is moot — both `order.created` and `order.deleted` carry 404 bodies on the toggle-OFF SaaS-DELETE-race path until the SaaS-side fix lands, so delivering vs. suppressing a 404-bodied `order.deleted` is indistinguishable to Shippo.

Shipping the minimum-surface fix here. Happy to follow up with the stronger fix if customer feedback shows the toggle-OFF order.deleted suppression matters in practice.

## Test plan

- [x] Customer reported the regression on nicholaslodge.com toggle-OFF; this fix targets the exact branch.
- [x] Five-lens subagent review: no side effects, no doc drift, comment style matches, transient is isolated (single set, single get, single filter), no tests to update.
- [x] `php -l` clean.

## Verification status

This is a one-line tightening of an over-broad conjunct introduced by PR #207. The pre-existing webhook tests on grounded-mole, merciful-penguin, and nicholaslodge are sufficient — once auto-deploy lands, the customer can rerun their toggle-OFF flow and confirm Shippo sees the `order.created` attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)