### PR TITLE
fix(helper): guard dbDelta callsites against install-helper.php redeclare fatal

### DIFF
--- a/checkview.php
+++ b/checkview.php
@@ -75,6 +75,10 @@ if ( ! defined( 'CHECKVIEW_URI' ) ) {
  * Handles CheckView activation.
  */
 function activate_checkview() {
+	// checkview-functions.php is normally loaded on plugins_loaded, which
+	// hasn't fired yet during activation. Pull it in so the activator can
+	// call checkview_dbdelta_or_query().
+	require_once plugin_dir_path( __FILE__ ) . 'includes/checkview-functions.php';
 	require_once plugin_dir_path( __FILE__ ) . 'includes/class-checkview-activator.php';
 	Checkview_Activator::activate();
 }

--- a/includes/API/class-checkview-api.php
+++ b/includes/API/class-checkview-api.php
@@ -2571,23 +2571,15 @@ class CheckView_Api {
 			)
 		);
 		if ( $table_exists !== $cv_used_nonces ) {
-			// Include upgrade.php for dbDelta.
-			if ( ! function_exists( 'dbDelta' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-			}
-			$cv_used_nonces = $wpdb->prefix . 'cv_used_nonces';
-
 			$charset_collate = $wpdb->get_charset_collate();
-			if ( $wpdb->get_var( "SHOW TABLES LIKE '{$cv_used_nonces}'" ) !== $cv_used_nonces ) {
-				$sql = "CREATE TABLE $cv_used_nonces (
-						id BIGINT(20) NOT NULL AUTO_INCREMENT,
-						nonce VARCHAR(255) NOT NULL,
-						used_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-						PRIMARY KEY (id),
-						UNIQUE KEY nonce (nonce)
-					) $charset_collate;";
-				dbDelta( $sql );
-			}
+			$sql = "CREATE TABLE IF NOT EXISTS $cv_used_nonces (
+					id BIGINT(20) NOT NULL AUTO_INCREMENT,
+					nonce VARCHAR(255) NOT NULL,
+					used_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+					PRIMARY KEY (id),
+					UNIQUE KEY nonce (nonce)
+				) $charset_collate;";
+			checkview_dbdelta_or_query( $sql );
 			Checkview_Admin_Logs::add( 'api-logs', 'Nonce table absent, created.' );
 		}
 		// Check if the nonce exists.

--- a/includes/checkview-functions.php
+++ b/includes/checkview-functions.php
@@ -18,6 +18,77 @@ if ( ! defined( 'WPINC' ) ) {
 	die( 'Direct access not Allowed.' );
 }
 
+if ( ! function_exists( 'checkview_dbdelta_or_query' ) ) {
+	/**
+	 * Runs a CREATE TABLE statement via dbDelta() when safe, otherwise falls
+	 * back to a direct $wpdb->query().
+	 *
+	 * WordPress core ships two files that both unconditionally declare
+	 * maybe_create_table() and maybe_add_column(): wp-admin/install-helper.php
+	 * and wp-admin/includes/upgrade.php. If another plugin (or a core upgrade
+	 * flow) has already loaded install-helper.php, our own require_once of
+	 * upgrade.php triggers a fatal "Cannot redeclare maybe_create_table()".
+	 *
+	 * Detect the conflict by checking for maybe_create_table() — not dbDelta()
+	 * — and fall back to a direct query so the SQL still runs.
+	 *
+	 * Pass literal SQL only. The fallback path skips $wpdb->prepare(); user
+	 * input must not reach $sql.
+	 *
+	 * The fallback skips dbDelta's schema-diff, so ALTER-style migrations
+	 * (adding columns / keys to an existing table) must be written as
+	 * explicit ALTER TABLE statements instead of relying on this helper.
+	 *
+	 * Callers may pass `CREATE TABLE IF NOT EXISTS` for race-safety in the
+	 * raw fallback path; the helper strips `IF NOT EXISTS` before handing the
+	 * SQL to dbDelta(), because dbDelta's table-name regex captures the first
+	 * whitespace-delimited token after `CREATE TABLE` and would otherwise
+	 * extract the literal string "IF", silently bypassing its schema-diff.
+	 *
+	 * @since 2.0.36
+	 *
+	 * @param string $sql CREATE TABLE statement.
+	 * @return mixed dbDelta() result array, or $wpdb->query() return value.
+	 */
+	function checkview_dbdelta_or_query( $sql ) {
+		global $wpdb;
+		// Strip IF NOT EXISTS for the dbDelta path only. See docblock above
+		// — dbDelta's regex would otherwise treat "IF" as the table name.
+		$dbdelta_sql = preg_replace(
+			'/^(\s*CREATE\s+TABLE\s+)IF\s+NOT\s+EXISTS\s+/i',
+			'$1',
+			$sql
+		);
+		if ( function_exists( 'dbDelta' ) ) {
+			return dbDelta( $dbdelta_sql );
+		}
+		if ( ! function_exists( 'maybe_create_table' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+			return dbDelta( $dbdelta_sql );
+		}
+		// install-helper.php was loaded first by another plugin or core
+		// upgrade routine; requiring upgrade.php now would fatal. Keep
+		// IF NOT EXISTS in the raw $sql so the fallback stays race-safe.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$result = $wpdb->query( $sql );
+		if ( false === $result && ! empty( $wpdb->last_error ) ) {
+			// MySQL errors can contain newlines (multi-line diagnostics);
+			// flatten so a single log entry stays on one line.
+			$flat = preg_replace( '/[\r\n\0]+/', ' ', (string) $wpdb->last_error );
+			$msg  = 'checkview_dbdelta_or_query fallback failed: ' . $flat;
+			if ( class_exists( 'Checkview_Admin_Logs', false ) ) {
+				Checkview_Admin_Logs::add( 'api-logs', $msg );
+			} else {
+				// Checkview_Admin_Logs isn't loaded yet (e.g. during
+				// activation). Surface to PHP's error log so the failure
+				// isn't silently swallowed.
+				error_log( '[CheckView] ' . $msg );
+			}
+		}
+		return $result;
+	}
+}
+
 if ( ! function_exists( 'checkview_ensure_trailing_slash' ) ) {
 	/**
 	 * Ensures a string ends with a trailing slash.

--- a/includes/class-checkview-activator.php
+++ b/includes/class-checkview-activator.php
@@ -40,11 +40,10 @@ class Checkview_Activator {
 	 */
 	public static function checkview_run_sql() {
 		global $wpdb;
-		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
 		$cv_entry_table = $wpdb->prefix . 'cv_entry';
 		if ( $wpdb->get_var( $wpdb->prepare( 'show tables like %s', $cv_entry_table ) ) !== $cv_entry_table ) {
-			$sql  = "CREATE TABLE  `$cv_entry_table` (";
+			$sql  = "CREATE TABLE IF NOT EXISTS `$cv_entry_table` (";
 			$sql .= '`id` int(10) unsigned NOT NULL AUTO_INCREMENT,';
 			$sql .= '`form_id` mediumint(10) unsigned NOT NULL,';
 			$sql .= '`uid` varchar(255) COLLATE utf8mb4_unicode_520_ci NOT NULL,';
@@ -71,11 +70,11 @@ class Checkview_Activator {
 			$sql .= 'PRIMARY KEY (`id`),';
 			$sql .= 'KEY `form_id` (`form_id`)';
 			$sql .= ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;';
-			dbDelta( $sql );
+			checkview_dbdelta_or_query( $sql );
 		}
 		$cv_entry_meta_table = $wpdb->prefix . 'cv_entry_meta';
 		if ( $wpdb->get_var( $wpdb->prepare( 'show tables like %s', $cv_entry_meta_table ) ) !== $cv_entry_meta_table ) {
-			$sql  = "CREATE TABLE `$cv_entry_meta_table` (";
+			$sql  = "CREATE TABLE IF NOT EXISTS `$cv_entry_meta_table` (";
 			$sql .= '`id` bigint(10) unsigned NOT NULL AUTO_INCREMENT,';
 			$sql .= '`form_id` mediumint(10) unsigned NOT NULL DEFAULT 0,';
 			$sql .= '`uid` varchar(255) COLLATE utf8mb4_unicode_520_ci NOT NULL,';
@@ -88,31 +87,31 @@ class Checkview_Activator {
 			$sql .= 'KEY `entry_id` (`entry_id`),';
 			$sql .= 'KEY `meta_value` (`meta_value`(191))';
 			$sql .= ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;';
-			dbDelta( $sql );
+			checkview_dbdelta_or_query( $sql );
 		}
 
 		$cv_session_table = $wpdb->prefix . 'cv_session';
 		if ( $wpdb->get_var( $wpdb->prepare( 'show tables like %s', $cv_session_table ) ) !== $cv_session_table ) {
-			$sql  = "CREATE TABLE `$cv_session_table` (";
+			$sql  = "CREATE TABLE IF NOT EXISTS `$cv_session_table` (";
 			$sql .= '`visitor_ip` varchar(255) DEFAULT NULL,';
 			$sql .= '`test_key` varchar(255) DEFAULT NULL,';
 			$sql .= '`test_id` varchar(255) DEFAULT NULL';
 			$sql .= ') ENGINE=InnoDB DEFAULT CHARSET=utf8;';
-			dbDelta( $sql );
+			checkview_dbdelta_or_query( $sql );
 		}
 
 		$cv_used_nonces = $wpdb->prefix . 'cv_used_nonces';
 
 		$charset_collate = $wpdb->get_charset_collate();
 		if ( $wpdb->get_var( $wpdb->prepare( 'show tables like %s', $cv_used_nonces ) ) !== $cv_used_nonces ) {
-				$sql = "CREATE TABLE $cv_used_nonces (
+				$sql = "CREATE TABLE IF NOT EXISTS $cv_used_nonces (
 				id BIGINT(20) NOT NULL AUTO_INCREMENT,
 				nonce VARCHAR(255) NOT NULL,
 				used_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
 				PRIMARY KEY (id),
 				UNIQUE KEY nonce (nonce)
 			) $charset_collate;";
-			dbDelta( $sql );
+			checkview_dbdelta_or_query( $sql );
 		}
 	}
 }

--- a/includes/class-checkview.php
+++ b/includes/class-checkview.php
@@ -456,22 +456,18 @@ class CheckView {
 			foreach ( $options['plugins'] as $plugin ) {
 				if ( CHECKVIEW_BASE_DIR === $plugin ) {
 					checkview_reset_cache( true );
-					// Include upgrade.php for dbDelta.
-					if ( ! function_exists( 'dbDelta' ) ) {
-						require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-					}
 					$cv_used_nonces = $wpdb->prefix . 'cv_used_nonces';
 
 					$charset_collate = $wpdb->get_charset_collate();
 					if ( $wpdb->get_var( "SHOW TABLES LIKE '{$cv_used_nonces}'" ) !== $cv_used_nonces ) {
-						$sql = "CREATE TABLE $cv_used_nonces (
+						$sql = "CREATE TABLE IF NOT EXISTS $cv_used_nonces (
 								id BIGINT(20) NOT NULL AUTO_INCREMENT,
 								nonce VARCHAR(255) NOT NULL,
 								used_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
 								PRIMARY KEY (id),
 								UNIQUE KEY nonce (nonce)
 							) $charset_collate;";
-						dbDelta( $sql );
+						checkview_dbdelta_or_query( $sql );
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

- Fixes PHP fatal `Cannot redeclare maybe_create_table()` when another plugin loads `wp-admin/install-helper.php` before CheckView requires `wp-admin/includes/upgrade.php`.
- Reproduced on a customer site whose `lcbrq-map` plugin loads `install-helper.php` on every request. 76 of 77 PHP fatals on that site in the last 60 days trace to this conflict.
- Introduces `checkview_dbdelta_or_query()` helper that detects the conflict via `function_exists('maybe_create_table')` (not `dbDelta` — that check is insufficient) and falls back to direct `$wpdb->query()`.

## Why the obvious guard wasn't enough

The three callsites already had `if ( ! function_exists( 'dbDelta' ) ) { require_once …upgrade.php; }`. That doesn't help here: when only `install-helper.php` has been loaded, `dbDelta` is genuinely undefined, the guard passes, and the require still fatals.

## Changes
- New `checkview_dbdelta_or_query()` in `includes/checkview-functions.php` — detects conflict, falls back to raw query, strips `IF NOT EXISTS` for the dbDelta path (dbDelta's regex would treat "IF" as the table name otherwise), flattens `$wpdb->last_error` CR/LF, logs via `Checkview_Admin_Logs` or `error_log` fallback.
- Eager-load `checkview-functions.php` in `activate_checkview()` so the helper is available during the activation hook (which fires before `plugins_loaded`).
- All 5 `CREATE TABLE` statements now use `IF NOT EXISTS` (race-safety on the raw-query path; harmless on dbDelta path since the helper strips it).
- All 3 production callsites swapped from `dbDelta()` to `checkview_dbdelta_or_query()`.

## Test plan
- [ ] Activate on clean WP install → all 4 tables (`cv_entry`, `cv_entry_meta`, `cv_session`, `cv_used_nonces`) create normally via the dbDelta path
- [ ] Drop an mu-plugin that does `require_once ABSPATH . 'wp-admin/install-helper.php';` then activate CheckView → no fatal, tables create via fallback (verified on customer site that the diagnosis matches)
- [ ] Force a fallback SQL failure (e.g., revoke `CREATE` grant temporarily) → entry appears in `wp-content/uploads/checkview-logs/api-logs-log-YYYY-MM-DD.log` (or PHP `error_log` if `Checkview_Admin_Logs` not loaded yet during activation)
- [ ] PHP lint clean: `php -l` on all 5 changed files (already verified locally)

## Files
- `checkview.php` — activation: eager-load helper
- `includes/checkview-functions.php` — new helper (~70 lines)
- `includes/class-checkview.php` — `upgrader_process_complete` callback uses helper
- `includes/class-checkview-activator.php` — 4 CREATEs use helper
- `includes/API/class-checkview-api.php` — nonce-table CREATE uses helper

## Notes
- No version bump (per project convention for fix branches).
- Comprehensive review notes (4 rounds, 20 subagents) covered: regex robustness, WP/PHP version compat, lifecycle edges, security/SQL-injection surface, concurrency, canonical-fix benchmark vs WooCommerce/Yoast pattern. All findings addressed.
- Reference: WP Trac [#6747](https://core.trac.wordpress.org/ticket/6747), [#5090](https://core.trac.wordpress.org/ticket/5090).

🤖 Generated with [Claude Code](https://claude.com/claude-code)