### PR TITLE
fix(gforms): redirect notification mail to test inbox under GF 2.10 Background Notifications

### DIFF
--- a/admin/class-checkview-admin.php
+++ b/admin/class-checkview-admin.php
@@ -554,6 +554,12 @@ class Checkview_Admin {
 		delete_transient( 'checkview_forms_test_transient' );
 		delete_transient( 'checkview_store_orders_transient' );
 
+		// Form-plugin-agnostic wp_mail backstop. Loaded before any form helper so
+		// the wp_mail filter is registered regardless of which form plugin is
+		// active (and even if no form helper claims the request).
+		Checkview_Admin_Logs::add( 'ip-logs', 'Loading wp_mail redirect backstop.' );
+		require_once CHECKVIEW_INC_DIR . 'class-checkview-mail-redirect.php';
+
 		if ( is_plugin_active( 'gravityforms/gravityforms.php' ) ) {
 			Checkview_Admin_Logs::add( 'ip-logs', 'Loading Gravity Forms helper.' );
 

--- a/includes/class-checkview-mail-redirect.php
+++ b/includes/class-checkview-mail-redirect.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Checkview_Mail_Redirect class
+ *
+ * Form-plugin-agnostic backstop that rewrites wp_mail recipients to TEST_EMAIL
+ * during a CheckView test. Catches notification paths that bypass the per-
+ * plugin filters (gform_pre_send_email, wpforms_email_send_*, etc.) — e.g.,
+ * when a transactional-email plugin (Postmark, FluentSMTP, SendGrid) overrides
+ * wp_mail, or when a third-party integration sends notifications outside the
+ * form plugin's standard chain.
+ *
+ * Runs only when TEST_EMAIL is defined (i.e., inside a verified test session),
+ * at wp_mail filter priority 999 so transport plugins have already applied
+ * their own modifications before we rewrite the recipient.
+ *
+ * @since 2.0.35
+ * @package Checkview
+ * @subpackage Checkview/includes
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+	die( 'Direct access not Allowed.' );
+}
+
+if ( ! class_exists( 'Checkview_Mail_Redirect' ) ) {
+
+	/**
+	 * Rewrites wp_mail recipients to TEST_EMAIL during a CheckView test.
+	 *
+	 * Acts as a backstop for cases where form-plugin-specific filters
+	 * (gform_pre_send_email, wpforms_*, etc.) do not fire — for example, when a
+	 * custom snippet or third-party integration sends the form notification via
+	 * wp_mail directly, bypassing the form plugin's standard notification chain.
+	 *
+	 * @author Check View <support@checkview.io>
+	 */
+	class Checkview_Mail_Redirect {
+
+		/**
+		 * Constructor — registers the wp_mail filter when in test context.
+		 */
+		public function __construct() {
+			if ( ! defined( 'TEST_EMAIL' ) || '' === (string) TEST_EMAIL ) {
+				return;
+			}
+
+			// Priority 999: run after most other wp_mail filters (transport
+			// plugins, GF Postmark add-on, etc.) so we rewrite the final
+			// recipient just before send.
+			add_filter( 'wp_mail', array( $this, 'redirect_recipient' ), 999, 1 );
+		}
+
+		/**
+		 * Rewrites the wp_mail recipient to the CheckView test inbox.
+		 *
+		 * Mirrors Checkview_Gforms_Helper::checkview_inject_email() behavior:
+		 * - Default (REPLACE): replace `to` with TEST_EMAIL and strip Cc/Bcc.
+		 * - When `disable_email_receipt_<test_id>` option is 'true' (APPEND):
+		 *   append TEST_EMAIL to the existing recipients rather than replacing.
+		 *
+		 * Two skip conditions avoid double-work when an earlier filter
+		 * (e.g. gform_pre_send_email at priority 99) already did the rewrite:
+		 * - REPLACE mode: skip if $to is already exactly TEST_EMAIL.
+		 * - APPEND mode: skip if $to already contains TEST_EMAIL.
+		 *
+		 * @param mixed $atts wp_mail compact args (to/subject/message/headers/attachments).
+		 * @return mixed Modified args (or original if not applicable).
+		 */
+		public function redirect_recipient( $atts ) {
+			if ( ! is_array( $atts ) || empty( $atts['to'] ) ) {
+				return $atts;
+			}
+
+			$cv_test_id  = get_checkview_test_id();
+			$append_mode = $cv_test_id
+				&& 'true' === get_option( 'disable_email_receipt_' . $cv_test_id, false );
+
+			if ( $append_mode ) {
+				if ( $this->contains_test_email( $atts['to'] ) ) {
+					return $atts;
+				}
+				$original_to = $atts['to'];
+				if ( is_array( $atts['to'] ) ) {
+					$atts['to'][] = TEST_EMAIL;
+				} else {
+					$atts['to'] .= ', ' . TEST_EMAIL;
+				}
+			} else {
+				if ( $this->is_only_test_email( $atts['to'] ) ) {
+					return $atts;
+				}
+				$original_to     = $atts['to'];
+				$atts['to']      = TEST_EMAIL;
+				$atts['headers'] = $this->strip_cc_bcc_headers( $atts['headers'] ?? '' );
+			}
+
+			Checkview_Admin_Logs::add(
+				'ip-logs',
+				'wp_mail backstop: rewrote recipient from ' . wp_json_encode( $original_to ) . ' to ' . wp_json_encode( $atts['to'] )
+			);
+
+			return $atts;
+		}
+
+		/**
+		 * True if any address in $to is exactly TEST_EMAIL (case-insensitive).
+		 *
+		 * Tokenises the recipient by comma/whitespace and compares each token
+		 * for exact equality with TEST_EMAIL — avoids substring false-positives
+		 * like "abc@test-mail.checkview.io.attacker.com".
+		 *
+		 * @param array|string $to Current recipient(s).
+		 * @return bool
+		 */
+		private function contains_test_email( $to ): bool {
+			$addresses = is_array( $to ) ? $to : preg_split( '/[,\s]+/', (string) $to );
+			foreach ( (array) $addresses as $addr ) {
+				if ( ! is_string( $addr ) ) {
+					continue;
+				}
+				if ( 0 === strcasecmp( trim( $addr ), TEST_EMAIL ) ) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/**
+		 * True if $to is exactly one address and that address is TEST_EMAIL.
+		 *
+		 * Used to skip rewriting in REPLACE mode when an earlier filter already
+		 * set $to to TEST_EMAIL — prevents a redundant log line.
+		 *
+		 * @param array|string $to Current recipient(s).
+		 * @return bool
+		 */
+		private function is_only_test_email( $to ): bool {
+			if ( is_string( $to ) ) {
+				$tokens = preg_split( '/[,\s]+/', $to, -1, PREG_SPLIT_NO_EMPTY );
+				return is_array( $tokens )
+					&& count( $tokens ) === 1
+					&& 0 === strcasecmp( $tokens[0], TEST_EMAIL );
+			}
+			if ( is_array( $to ) && 1 === count( $to ) ) {
+				$only = reset( $to );
+				return is_string( $only ) && 0 === strcasecmp( trim( $only ), TEST_EMAIL );
+			}
+			return false;
+		}
+
+		/**
+		 * Removes Cc: and Bcc: headers so other recipients don't receive the test email.
+		 *
+		 * Preserves the input type: string in → string out, array in → array out.
+		 * Avoids type changes that downstream transport plugins might mishandle.
+		 *
+		 * @param array|string $headers Original headers.
+		 * @return array|string Filtered headers.
+		 */
+		private function strip_cc_bcc_headers( $headers ) {
+			$was_string = ! is_array( $headers );
+			$list       = $was_string ? explode( "\r\n", (string) $headers ) : $headers;
+
+			$filtered = array_values(
+				array_filter(
+					$list,
+					function ( $header ) {
+						if ( ! is_string( $header ) ) {
+							return true;
+						}
+						$lower = strtolower( ltrim( $header ) );
+						return 0 !== strpos( $lower, 'bcc:' ) && 0 !== strpos( $lower, 'cc:' );
+					}
+				)
+			);
+
+			return $was_string ? implode( "\r\n", $filtered ) : $filtered;
+		}
+	}
+
+	new Checkview_Mail_Redirect();
+}

--- a/includes/class-checkview-mail-redirect.php
+++ b/includes/class-checkview-mail-redirect.php
@@ -159,7 +159,7 @@ if ( ! class_exists( 'Checkview_Mail_Redirect' ) ) {
 		 */
 		private function strip_cc_bcc_headers( $headers ) {
 			$was_string = ! is_array( $headers );
-			$list       = $was_string ? explode( "\r\n", (string) $headers ) : $headers;
+			$list       = $was_string ? preg_split( '/\r?\n/', (string) $headers ) : $headers;
 
 			$filtered = array_values(
 				array_filter(

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -73,6 +73,21 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 					1
 				);
 
+				// Force notifications to dispatch synchronously during a test.
+				// GF 2.10+ ships "Background Notifications" (queued via the
+				// GF_Notifications_Processor admin-ajax task). That separate
+				// request doesn't carry the CheckView test context, so
+				// TEST_EMAIL is never defined for it and gform_pre_send_email
+				// above never fires — the notification goes to the original
+				// recipient. Forcing sync during the test keeps the dispatch
+				// inside the form-submission request where our filters are
+				// already registered. Customers' non-test traffic is
+				// unaffected.
+				add_filter(
+					'gform_is_asynchronous_notifications_enabled',
+					'__return_false',
+					999
+				);
 			}
 			// Disable addons found in forms.
 			add_filter(


### PR DESCRIPTION
## Summary

- Forces Gravity Forms to dispatch notifications synchronously during a CheckView test, so the helper plugin's existing `gform_pre_send_email` filter actually runs and the test inbox receives the email instead of the customer-configured recipients
- Adds a form-plugin-agnostic `wp_mail` filter backstop for the rare case where a notification still reaches `wp_mail()` via a path that bypasses `gform_pre_send_email` (e.g. CRM addon or custom snippet sending email outside GF's notification chain)
- ClickUp: [868jqupeh](https://app.clickup.com/t/868jqupeh)

## The bug

GF 2.10.0 (April 16, 2026) added a **"Background Notifications"** setting in Forms → Settings. When enabled, GF defers notification dispatch to a `GF_Notifications_Processor` task that runs in a **separate admin-ajax background-process request**, not inline with the form submission.

That separate request doesn't carry CheckView's test context: no bot IP, no `checkview_test_id` cookie or referer. `checkview_init_current_test()` never fires, `TEST_EMAIL` is never defined, and every recipient-rewrite filter in the GF helper bails at its `defined('TEST_EMAIL')` gate. The notification goes to the original customer-configured recipient.

Reproduced on rubberduckers.co.uk (form 14). Confirmed via mu-plugin tracer that captured the backtrace for the failing notification:

```
cv_mail_redirect_backstop  ← our filter
WP_Hook->apply_filters
apply_filters (wp-mail.php)  ← ActiveCampaign Postmark plugin's wp_mail override
wp_mail (common.php)
GFCommon::send_email
GFCommon::send_notification
GFCommon::send_notifications (class-gf-notifications-processor.php:104)
Gravity_Forms\Async\GF_Notifications_Processor->task
Gravity_Forms\Async\GF_Background_Process->handle
Gravity_Forms\Async\GF_Background_Process->maybe_handle
WP_Hook->do_action
do_action (admin-ajax.php)
```

With `TEST_EMAIL_defined: false` at that point in the request.

GF defaults Background Notifications **on** for new installs. Existing installs inherit their prior setting on upgrade. The setting can be toggled per-site from the GF admin at any time.

## Fixes

### 1. Force sync notifications during a test (primary fix)

In `Checkview_Gforms_Helper::__construct`, inside the existing `if ( defined( 'TEST_EMAIL' ) )` block:

```php
add_filter(
    'gform_is_asynchronous_notifications_enabled',
    '__return_false',
    999
);
```

Filter name is `gform_is_asynchronous_notifications_enabled` (note: **asynchronous**, not async — defined at `gravityforms/includes/async/class-gf-notifications-processor.php:140`). Gating on `TEST_EMAIL` ensures customers' non-test traffic continues to benefit from async dispatch.

### 2. Form-plugin-agnostic wp_mail backstop (defense in depth)

New `Checkview_Mail_Redirect` class at `includes/class-checkview-mail-redirect.php`, loaded right after `TEST_EMAIL` is defined and before any form helper. Hooks `wp_mail` filter at priority 999 (after transport plugins like Postmark / FluentSMTP / SendGrid have applied their changes) and rewrites `$atts['to']` to `TEST_EMAIL` when in test context.

Covers cases where a notification reaches `wp_mail()` via a path that bypassed `gform_pre_send_email` entirely — e.g. a CRM addon firing on `gform_after_submission` and calling `wp_mail()` directly, or a custom snippet doing the same. Not strictly needed once the async fix is in for GF, but the pattern of async-dispatch is likely to spread to other form plugins (Fluent, WPForms, etc.), and this is cheap.

Mode-aware skip checks prevent double-processing when `gform_pre_send_email` already ran:
- **Replace mode**: skip if `to` is exactly `TEST_EMAIL`
- **Append mode** (`disable_email_receipt_<test_id>` option = `'true'`): skip if `TEST_EMAIL` is already anywhere in `to`

Token-based contains-check (splits on comma/whitespace, exact case-insensitive match per token) avoids substring false-positives like `abc@test-mail.checkview.io.attacker.com`.

Cc/Bcc headers stripped in replace mode. Input type preserved (string in → string out, array in → array out) so downstream transports do not see surprising type changes.

## Test plan

- [ ] On a site with **Background Notifications enabled** in GF Settings, run a form test → `assert_email_received` passes
- [ ] On a site with **Background Notifications disabled**, run a form test → still passes (no regression from existing inline path)
- [ ] After a passing test, helper plugin `ip-logs` contains `Submission recipient email address: "<test_id>@test-mail.checkview.io"` (proves `gform_pre_send_email` fired and the existing filter rewrote the recipient inline)
- [ ] Customer submits the form for real (non-test) immediately after a CheckView test — notification still dispatches async / goes to the configured recipient (proves the filter is properly gated on `TEST_EMAIL`)
- [ ] Force a code path that bypasses `gform_pre_send_email` (custom snippet calling `wp_mail()` from `gform_after_submission` during a test) → wp_mail backstop log line appears: `wp_mail backstop: rewrote recipient from ... to ...`
- [ ] Existing CheckView tests on production fleet pass with no regression

## Deployment notes

- A temporary mu-plugin (`cv-mail-redirect.php` v1.0.0) is currently deployed on rubberduckers.co.uk to unblock that customer's tests immediately. Remove from the site after this PR ships in a helper plugin release.
- No version bump on this PR (per `feedback_helper_versioning` convention — version bumps happen at release time, not per-PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)