### PR TITLE
fix(compat): WP 7.0 compatibility — superglobal hygiene + header alignment

### DIFF
--- a/admin/class-checkview-admin.php
+++ b/admin/class-checkview-admin.php
@@ -224,14 +224,15 @@ class Checkview_Admin {
 
 		// 1. Check pretty permalinks (e.g. /wp-json/checkview/v1/...
 		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-			if ( preg_match( '#/wp-json/(checkview/.*)#', $_SERVER['REQUEST_URI'], $matches ) ) {
+			$request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+			if ( preg_match( '#/wp-json/(checkview/.*)#', $request_uri, $matches ) ) {
 				$rest_route = $matches[1];
 			}
 		}
 
 		// 2. Check plain permalinks (e.g. ?rest_route=/checkview/vw/...)
 		if ( empty( $rest_route ) && isset( $_GET['rest_route'] ) ) {
-			$route = ltrim( $_GET['rest_route' ], '/' );
+			$route = ltrim( esc_url_raw( wp_unslash( $_GET['rest_route'] ) ), '/' );
 			if ( strpos( $route, 'checkview/' ) === 0 ) {
 				$rest_route = $route;
 			}
@@ -318,7 +319,7 @@ class Checkview_Admin {
 			include_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$is_helper_api_request = isset( $_SERVER['REQUEST_URI'] ) && strpos( $_SERVER['REQUEST_URI'], '_checkview_timestamp' );
+		$is_helper_api_request = isset( $_SERVER['REQUEST_URI'] ) && strpos( esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '_checkview_timestamp' );
 		if ( $is_helper_api_request ) {
 			return;
 		}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0 || ^8.0",
+        "php": ">=7.4",
         "firebase/php-jwt": "^6.5",
         "paragonie/sodium_compat": "^1.20",
         "ext-json": "*"

--- a/includes/class-checkview.php
+++ b/includes/class-checkview.php
@@ -153,8 +153,11 @@ class CheckView {
 		$cv_test_id = get_checkview_test_id();
 		if ( ! empty( $cv_test_id ) ) {
 			$valid_values = array( 'woo_checkout', 'full_checkout', 'add_to_cart', 'form', 'custom' );
-			if ( isset( $_COOKIE[self::$bot_cookie] ) && in_array( $_COOKIE[self::$bot_cookie], $valid_values, true ) ) {
-				return $_COOKIE[self::$bot_cookie];
+			if ( isset( $_COOKIE[ self::$bot_cookie ] ) ) {
+				$cookie_value = sanitize_text_field( wp_unslash( $_COOKIE[ self::$bot_cookie ] ) );
+				if ( in_array( $cookie_value, $valid_values, true ) ) {
+					return $cookie_value;
+				}
 			}
 			return 'form';
 		}

--- a/includes/formhelpers/class-checkview-ninja-forms-helper.php
+++ b/includes/formhelpers/class-checkview-ninja-forms-helper.php
@@ -211,8 +211,8 @@ if ( ! class_exists( 'Checkview_Ninja_Forms_Helper' ) ) {
 			// The raw $_POST['formData'] JSON contains the original
 			// values submitted by the browser.
 			$raw_fields = array();
-			if ( isset( $_POST['formData'] ) ) {
-				$raw_form = json_decode( stripslashes( $_POST['formData'] ), true );
+			if ( isset( $_POST['formData'] ) && is_string( $_POST['formData'] ) ) {
+				$raw_form = json_decode( wp_unslash( $_POST['formData'] ), true );
 				if ( is_array( $raw_form ) && ! empty( $raw_form['fields'] ) && is_array( $raw_form['fields'] ) ) {
 					$raw_fields = $raw_form['fields'];
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: checkview, inspry
 Donate link: https://checkview.io/
 Tags: form testing, form monitoring, wordpress testing, woocommerce testing, site monitoring
 Requires at least: 5.0.1
-Tested up to: 6.9
-Requires PHP: 7.0.0
+Tested up to: 7.0
+Requires PHP: 7.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Stable tag: 2.0.35-beta


### PR DESCRIPTION
## Summary

Closing the gap on WordPress 7.0 compatibility surfaced by a 5-agent review of the development branch. Scope is intentionally narrow: superglobal hygiene, sanitizer choice on URIs, and header/composer alignment. No version bump.

## Changes

- **`esc_url_raw( wp_unslash( ... ) )`** on three URI reads in `admin/class-checkview-admin.php` (`$_SERVER['REQUEST_URI']` x2, `$_GET['rest_route']`). Replaces unwrapped reads; `esc_url_raw` chosen over `sanitize_text_field` because the latter strips `<…>` tokens and `%0A`-style percent-encoded CRLF from query strings (WP Core uses `esc_url_raw` for URI handling).
- **`sanitize_text_field( wp_unslash( ... ) )`** + single-read refactor on the `$_COOKIE` bot-cookie read in `includes/class-checkview.php`. Behaviorally identical for the 5 valid `test_type` values; in_array check still authoritative.
- **`wp_unslash` + `is_string` guard** on `$_POST['formData']` in `includes/formhelpers/class-checkview-ninja-forms-helper.php`. Replaces `stripslashes`; guard neutralizes the array-injection TypeError path that would otherwise hit `json_decode`.
- **`composer.json`**: `php` constraint `^5.6 || ^7.0 || ^8.0` → `>=7.4` (matches `Requires PHP: 7.4` in `checkview.php`).
- **`readme.txt`** (renamed from `README.txt` for case-sensitive FS): `Tested up to: 6.9 → 7.0`, `Requires PHP: 7.0.0 → 7.4`. WP 7.0 is the current core release (verified via wp.org version-check API).

## What this does NOT do

- No version bump (per dev-branch convention — version bumps are release events).
- No changes to `formhelpers/` beyond the NF guard (rest of helpers deferred — there are several in-flight branches there).
- No changes to REST routes (the destructive-GET routes `deletetestuser` / `deleteformstest` / `deleteorders` and the `methods`-omitting routes at lines 349/366/380/397 should be addressed in a separate PR alongside `fix/security-path-traversal-capability-checks`).
- No `wp_unslash` on `$_SERVER['REQUEST_METHOD']` at `checkview-functions.php:1021` — already filtered through `preg_replace('/[^A-Za-z]/', '', ...)` which strips everything but letters, so PHPCS may flag but functional risk is zero.

## Test plan

- [ ] `php -l` clean on all modified PHP files (verified locally)
- [ ] `composer.json` parses (verified locally)
- [ ] Smoke-test a CheckView test run on an InstaWP sandbox after this lands on `quality` — verify bot cookie still resolves, REST routes still match, NF form parsing still extracts fields.
- [ ] Watch CV pre-commit hooks (`includes/vendor/` excluded by .gitignore so no shifting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)