### PR TITLE
fix(gforms): scope validation bypass to anti-bot failures only

### DIFF
--- a/includes/checkview-helper-functions.php
+++ b/includes/checkview-helper-functions.php
@@ -110,24 +110,58 @@ if ( ! function_exists( 'checkview_hcap_whitelist_ip' ) ) {
 	add_filter( 'hcap_whitelist_ip', 'checkview_hcap_whitelist_ip', 10, 2 );
 }
 
+if ( ! function_exists( 'checkview_request_has_test_credentials' ) ) {
+	/**
+	 * Returns true if the current request carries a valid CheckView test
+	 * `test_id` + `test_type` pair in `$_REQUEST`.
+	 *
+	 * Used by `gform_loaded` bootstrap-time add-on removers that need to
+	 * fire very early in the request lifecycle — before the helper plugin's
+	 * normal init/cookie-based test detection has run. Only the initial GET
+	 * to a tested page carries these in `$_REQUEST`; AJAX submissions
+	 * resolve test context via cookie/referer instead (handled by
+	 * `checkview_init_current_test` → `defined('TEST_EMAIL')` downstream).
+	 *
+	 * Why a separate helper instead of reusing `checkview_is_valid_uuid()`:
+	 * that function logs every invalid input to `ip-logs`, which would spam
+	 * the log on every customer (non-test) request. This helper short-
+	 * circuits silently when the test credentials aren't present.
+	 *
+	 * SYNC: UUID regex must match `checkview_is_valid_uuid()` in
+	 * `checkview-functions.php`.
+	 *
+	 * @since 2.0.35
+	 * @return bool
+	 */
+	function checkview_request_has_test_credentials() {
+		if ( ! isset( $_REQUEST['checkview_test_id'] )
+			|| ! is_string( $_REQUEST['checkview_test_id'] )
+			|| empty( $_REQUEST['checkview_test_type'] ) ) {
+			return false;
+		}
+		$test_id = sanitize_text_field( wp_unslash( $_REQUEST['checkview_test_id'] ) );
+		return (bool) preg_match(
+			'/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i',
+			$test_id
+		);
+	}
+}
+
 if ( ! function_exists( 'remove_gravityforms_recaptcha_addon' ) ) {
 	/**
 	 * Removes ReCAPTCHA from GravityForms during CheckView tests.
 	 *
+	 * Fires on `gform_loaded` priority 1 (before the Add-On's priority-5
+	 * bootstrap). Only acts on initial GETs that carry the test credentials
+	 * in `$_REQUEST`; for AJAX form submissions the runtime
+	 * `Checkview_Gforms_Helper::unhook_gf_recaptcha_addon()` handles
+	 * removal via `remove_filter` on the live add-on instance.
+	 *
 	 * @return void
 	 */
 	function remove_gravityforms_recaptcha_addon() {
-		// Make sure the class exists before trying to remove the action.
 		if ( class_exists( 'GF_RECAPTCHA_Bootstrap' )
-			&& isset( $_REQUEST['checkview_test_id'] )
-			&& is_string( $_REQUEST['checkview_test_id'] )
-			// SYNC: Must match checkview_is_valid_uuid() in checkview-functions.php
-			&& preg_match(
-				'/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i',
-				sanitize_text_field( wp_unslash( $_REQUEST['checkview_test_id'] ) )
-			)
-			&& ! empty( $_REQUEST['checkview_test_type'] )
-		) {
+			&& checkview_request_has_test_credentials() ) {
 			remove_action( 'gform_loaded', array( 'GF_RECAPTCHA_Bootstrap', 'load_addon' ), 5 );
 		}
 	}
@@ -138,35 +172,29 @@ add_action( 'gform_loaded', 'remove_gravityforms_recaptcha_addon', 1 );
 if ( ! function_exists( 'remove_gravityforms_turnstile_addon' ) ) {
 	/**
 	 * Removes the GF Cloudflare Turnstile Add-On from loading during CheckView
-	 * tests. Mirrors `remove_gravityforms_recaptcha_addon()`.
+	 * tests. Sibling of `remove_gravityforms_recaptcha_addon()`.
 	 *
 	 * The add-on's slug is `gravityformscloudflareturnstile`; its bootstrap
-	 * class is `GF_Turnstile_Bootstrap` (registered on `gform_loaded`
-	 * priority 5). Removing it before it runs prevents the add-on from
-	 * registering the `turnstile` field type, so `GF_Field_Turnstile::validate`
-	 * never executes for the test submission.
+	 * class is `GF_Turnstile_Bootstrap` and its loader method `load` is
+	 * `public static` (registered on `gform_loaded` priority 5). Removing
+	 * it before it runs prevents the add-on from registering the
+	 * `turnstile` field type, so `GF_Field_Turnstile::validate` never
+	 * executes for the test submission.
 	 *
-	 * Belt-and-braces note: even without this early removal,
+	 * Belt-and-braces: even without this early removal,
 	 * `Checkview_Gforms_Helper::maybe_hide_recaptcha()` strips
 	 * `turnstile`-typed fields on `gform_pre_validation`, and
 	 * `is_anti_bot_failure()` covers the type in its allowlist. This
-	 * function is the equivalent of the reCAPTCHA version — same intent,
-	 * same restrictive `$_REQUEST` gate (only fires on the initial GET
-	 * where `checkview_test_id` is in the URL, not on AJAX submissions).
+	 * function targets the initial-GET path (where `checkview_test_id`
+	 * is in `$_REQUEST`); AJAX submissions resolve via the field-strip
+	 * path instead.
 	 *
+	 * @since 2.0.35
 	 * @return void
 	 */
 	function remove_gravityforms_turnstile_addon() {
 		if ( class_exists( 'GF_Turnstile_Bootstrap' )
-			&& isset( $_REQUEST['checkview_test_id'] )
-			&& is_string( $_REQUEST['checkview_test_id'] )
-			// SYNC: Must match checkview_is_valid_uuid() in checkview-functions.php
-			&& preg_match(
-				'/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i',
-				sanitize_text_field( wp_unslash( $_REQUEST['checkview_test_id'] ) )
-			)
-			&& ! empty( $_REQUEST['checkview_test_type'] )
-		) {
+			&& checkview_request_has_test_credentials() ) {
 			remove_action( 'gform_loaded', array( 'GF_Turnstile_Bootstrap', 'load' ), 5 );
 		}
 	}

--- a/includes/checkview-helper-functions.php
+++ b/includes/checkview-helper-functions.php
@@ -135,6 +135,45 @@ if ( ! function_exists( 'remove_gravityforms_recaptcha_addon' ) ) {
 // Use a hook with a priority higher than 5 to ensure the action is removed after it is added.
 add_action( 'gform_loaded', 'remove_gravityforms_recaptcha_addon', 1 );
 
+if ( ! function_exists( 'remove_gravityforms_turnstile_addon' ) ) {
+	/**
+	 * Removes the GF Cloudflare Turnstile Add-On from loading during CheckView
+	 * tests. Mirrors `remove_gravityforms_recaptcha_addon()`.
+	 *
+	 * The add-on's slug is `gravityformscloudflareturnstile`; its bootstrap
+	 * class is `GF_Turnstile_Bootstrap` (registered on `gform_loaded`
+	 * priority 5). Removing it before it runs prevents the add-on from
+	 * registering the `turnstile` field type, so `GF_Field_Turnstile::validate`
+	 * never executes for the test submission.
+	 *
+	 * Belt-and-braces note: even without this early removal,
+	 * `Checkview_Gforms_Helper::maybe_hide_recaptcha()` strips
+	 * `turnstile`-typed fields on `gform_pre_validation`, and
+	 * `is_anti_bot_failure()` covers the type in its allowlist. This
+	 * function is the equivalent of the reCAPTCHA version — same intent,
+	 * same restrictive `$_REQUEST` gate (only fires on the initial GET
+	 * where `checkview_test_id` is in the URL, not on AJAX submissions).
+	 *
+	 * @return void
+	 */
+	function remove_gravityforms_turnstile_addon() {
+		if ( class_exists( 'GF_Turnstile_Bootstrap' )
+			&& isset( $_REQUEST['checkview_test_id'] )
+			&& is_string( $_REQUEST['checkview_test_id'] )
+			// SYNC: Must match checkview_is_valid_uuid() in checkview-functions.php
+			&& preg_match(
+				'/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i',
+				sanitize_text_field( wp_unslash( $_REQUEST['checkview_test_id'] ) )
+			)
+			&& ! empty( $_REQUEST['checkview_test_type'] )
+		) {
+			remove_action( 'gform_loaded', array( 'GF_Turnstile_Bootstrap', 'load' ), 5 );
+		}
+	}
+}
+// Use a hook with a priority higher than 5 to ensure the action is removed after it is added.
+add_action( 'gform_loaded', 'remove_gravityforms_turnstile_addon', 1 );
+
 add_filter(
 	'wpforms_load_providers',
 	'checkview_disable_addons_providers',

--- a/includes/checkview-helper-functions.php
+++ b/includes/checkview-helper-functions.php
@@ -113,14 +113,21 @@ if ( ! function_exists( 'checkview_hcap_whitelist_ip' ) ) {
 if ( ! function_exists( 'checkview_request_has_test_credentials' ) ) {
 	/**
 	 * Returns true if the current request carries a valid CheckView test
-	 * `test_id` + `test_type` pair in `$_REQUEST`.
+	 * `test_id` + `test_type` pair in the URL query string.
 	 *
 	 * Used by `gform_loaded` bootstrap-time add-on removers that need to
 	 * fire very early in the request lifecycle — before the helper plugin's
 	 * normal init/cookie-based test detection has run. Only the initial GET
-	 * to a tested page carries these in `$_REQUEST`; AJAX submissions
+	 * to a tested page carries these in the query string; AJAX submissions
 	 * resolve test context via cookie/referer instead (handled by
 	 * `checkview_init_current_test` → `defined('TEST_EMAIL')` downstream).
+	 *
+	 * Gates on `$_GET` (not `$_REQUEST`) so a stale `checkview_test_id`
+	 * cookie from a prior test run cannot trigger bootstrap-time add-on
+	 * removal for unrelated subsequent requests from the same browser. The
+	 * test runner always navigates with `?checkview_test_id=...&
+	 * checkview_test_type=...` (browser context re-injects on every same-
+	 * domain navigation), so `$_GET` is sufficient for legitimate traffic.
 	 *
 	 * Why a separate helper instead of reusing `checkview_is_valid_uuid()`:
 	 * that function logs every invalid input to `ip-logs`, which would spam
@@ -134,12 +141,12 @@ if ( ! function_exists( 'checkview_request_has_test_credentials' ) ) {
 	 * @return bool
 	 */
 	function checkview_request_has_test_credentials() {
-		if ( ! isset( $_REQUEST['checkview_test_id'] )
-			|| ! is_string( $_REQUEST['checkview_test_id'] )
-			|| empty( $_REQUEST['checkview_test_type'] ) ) {
+		if ( ! isset( $_GET['checkview_test_id'] )
+			|| ! is_string( $_GET['checkview_test_id'] )
+			|| empty( $_GET['checkview_test_type'] ) ) {
 			return false;
 		}
-		$test_id = sanitize_text_field( wp_unslash( $_REQUEST['checkview_test_id'] ) );
+		$test_id = sanitize_text_field( wp_unslash( $_GET['checkview_test_id'] ) );
 		return (bool) preg_match(
 			'/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i',
 			$test_id
@@ -153,7 +160,7 @@ if ( ! function_exists( 'remove_gravityforms_recaptcha_addon' ) ) {
 	 *
 	 * Fires on `gform_loaded` priority 1 (before the Add-On's priority-5
 	 * bootstrap). Only acts on initial GETs that carry the test credentials
-	 * in `$_REQUEST`; for AJAX form submissions the runtime
+	 * in the URL query string; for AJAX form submissions the runtime
 	 * `Checkview_Gforms_Helper::unhook_gf_recaptcha_addon()` handles
 	 * removal via `remove_filter` on the live add-on instance.
 	 *

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -122,15 +122,21 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 				// true, which causes `testSpam()` to return the unmodified
 				// `$is_spam` without calling the API or `delete_lead()`.
 				//
-				// Sources (cleantalk-spam-protect plugin, wp.org trunk):
-				//   - inc/cleantalk-public-integrations.php ~L3148-3180
+				// Sources (cleantalk-spam-protect plugin, wp.org trunk;
+				// line numbers verified at the time of writing — re-verify
+				// on plugin updates):
+				//   - inc/cleantalk-public-integrations.php L2270-2303
 				//     (`apbct_form__gravityForms__isSkippedRequest()`
 				//     reads `$cleantalk_executed`)
-				//   - inc/cleantalk-public-integrations.php ~L3058-3068
+				//   - inc/cleantalk-public-integrations.php L2128-2134
 				//     (`apbct_form__gravityForms__testSpam()` calls
-				//     `isSkippedRequest()` first)
-				//   - inc/cleantalk-public-validate.php L311-313
-				//     (CleanTalk sets the global itself after API calls)
+				//     `isSkippedRequest()` first, returns `$is_spam`
+				//     unmodified before the remote API call or
+				//     `GFFormsModel::delete_lead()`)
+				//   - inc/cleantalk-public-validate.php L472
+				//     (CleanTalk sets the global itself after successful
+				//     base API calls — pattern is canonical, not
+				//     internal-only)
 				//
 				// CAVEAT: this is an INTERNAL global, not a documented
 				// public API. CleanTalk could rename/remove it in any

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -410,6 +410,11 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 					// Maspik's default error string (the plugin slug itself
 					// never appears in the user-facing message).
 					'looks like spam',
+					// Gravity Wiz GP Blocklist default message
+					// ("This field contains a disallowed term.") and any
+					// custom blocklist-style messages.
+					'blocklist',
+					'disallowed',
 				)
 			);
 			foreach ( (array) $bypass_markers as $marker ) {
@@ -453,6 +458,18 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		 * @return array
 		 */
 		public function unhook_gf_recaptcha_addon( $form ) {
+			// Idempotent — `gform_pre_validation` fires once per form, so on
+			// a page with multiple GF forms this callback would otherwise run
+			// repeatedly. After the first run the add-on's callbacks are
+			// already removed and subsequent runs would log a misleading
+			// "detected but no callbacks unhooked" warning. Static flag
+			// scopes the attempt to the first form-validation per request.
+			static $attempted = false;
+			if ( $attempted ) {
+				return $form;
+			}
+			$attempted = true;
+
 			if ( ! class_exists( 'GF_RECAPTCHA' ) || ! is_callable( array( 'GF_RECAPTCHA', 'get_instance' ) ) ) {
 				return $form;
 			}

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -88,6 +88,23 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 					'__return_false',
 					999
 				);
+
+				// Explicitly unhook the GF reCAPTCHA Add-On's callbacks during
+				// a test. Without this, the add-on's validate_submission()
+				// runs and attaches a failure to a non-captcha field
+				// (maybe_hide_recaptcha cannot catch it because the add-on
+				// doesn't use a captcha-type field). The
+				// checkview_bypass_captcha_validation marker fallback would
+				// still catch it, but explicit unhook is more precise and
+				// avoids depending on the English-only "recaptcha" substring.
+				// Hooked on gform_pre_validation at priority 1 so the
+				// unhook runs before gform_validation fires regardless of
+				// init ordering between this plugin and the add-on.
+				add_filter(
+					'gform_pre_validation',
+					array( $this, 'unhook_gf_recaptcha_addon' ),
+					1
+				);
 			}
 			// Disable addons found in forms.
 			add_filter(
@@ -402,6 +419,54 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 			}
 
 			return false;
+		}
+
+		/**
+		 * Removes the GF reCAPTCHA Add-On's callbacks at runtime so its
+		 * validation doesn't run during a CheckView test.
+		 *
+		 * The add-on (slug `gravityformsrecaptcha`, class `GF_RECAPTCHA`)
+		 * hooks both `gform_validation` (response token check) and
+		 * `gform_entry_is_spam` (low-score → spam) at default priority. Both
+		 * are removed here. Wider category-level filters (`gform_entry_is_spam`
+		 * → `__return_false`, marker-bypass in `checkview_bypass_captcha_validation`)
+		 * still catch the case where the class can't be found — e.g., a
+		 * future rename or a fork.
+		 *
+		 * Hooked at `gform_pre_validation` priority 1 so the unhook happens
+		 * before any `gform_validation` callback fires. Returns the form
+		 * unchanged.
+		 *
+		 * @since 2.0.35
+		 *
+		 * @param array $form The form being validated.
+		 * @return array
+		 */
+		public function unhook_gf_recaptcha_addon( $form ) {
+			if ( ! class_exists( 'GF_RECAPTCHA' ) || ! is_callable( array( 'GF_RECAPTCHA', 'get_instance' ) ) ) {
+				return $form;
+			}
+
+			$instance = GF_RECAPTCHA::get_instance();
+			if ( ! is_object( $instance ) ) {
+				return $form;
+			}
+
+			$removed = 0;
+			if ( method_exists( $instance, 'validate_submission' )
+				&& remove_filter( 'gform_validation', array( $instance, 'validate_submission' ) ) ) {
+				$removed++;
+			}
+			if ( method_exists( $instance, 'check_for_spam_entry' )
+				&& remove_filter( 'gform_entry_is_spam', array( $instance, 'check_for_spam_entry' ) ) ) {
+				$removed++;
+			}
+
+			if ( $removed > 0 ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Unhooked [' . $removed . '] GF reCAPTCHA Add-On callback(s).' );
+			}
+
+			return $form;
 		}
 
 		/**

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -395,18 +395,29 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 			$bypass_markers = apply_filters(
 				'checkview_anti_bot_validation_markers',
 				array(
+					// GF core `GF_Field_CAPTCHA` (Really Simple CAPTCHA / math
+					// captcha) default message contains "CAPTCHA". Separate
+					// from the GF reCAPTCHA Add-On (covered by the explicit
+					// `unhook_gf_recaptcha_addon()` runtime unhook).
 					'captcha',
+					// GF reCAPTCHA Add-On default messages (e.g. "The
+					// reCAPTCHA was invalid…") — defense-in-depth alongside
+					// the runtime unhook.
 					'recaptcha',
+					// Cloudflare Turnstile field-type error messages.
 					'turnstile',
-					// Note: `are you human` is a substring of common Cloudflare
-					// Turnstile and reCAPTCHA messages ("Please verify that you
-					// are human"), so the loop's first-match exit makes the
-					// longer phrasings redundant.
+					// Simple Cloudflare Turnstile default: "Please verify
+					// that you are human." `are you human` is a substring,
+					// so longer phrasings would be redundant via the
+					// first-match exit.
 					'are you human',
+					// ALTCHA Spam Protection (10k+ installs) GF field
+					// integration emits `"Could not verify you are not a
+					// robot."` from `validate()`.
 					'verify you are not a robot',
-					'bot detection',
-					// Maspik's default error string (the plugin slug itself
-					// never appears in the user-facing message).
+					// Maspik default ("This looks like spam. Try to
+					// rephrase…"). The plugin slug never appears in the
+					// user-facing message — match on the phrase instead.
 					'looks like spam',
 				)
 			);

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -305,17 +305,35 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		/**
 		 * Determines whether a field's validation failure is anti-bot/captcha related.
 		 *
-		 * Matches by field type (`captcha`, `hcaptcha`, `turnstile`) or by validation
-		 * message pattern — the GF reCAPTCHA Add-On v2.x and similar anti-bot validators
-		 * attach their failure to ordinary fields (often a hidden text or form-level
-		 * marker) rather than a captcha-type field.
+		 * Matches by field type (`captcha`, `hcaptcha`, `turnstile`, `honeypot`) or
+		 * by validation message pattern — the GF reCAPTCHA Add-On v2.x and similar
+		 * anti-bot validators attach their failure to ordinary fields (often a
+		 * hidden text or form-level marker) rather than a captcha-type field.
+		 *
+		 * The type allowlist is filterable via `checkview_anti_bot_field_types`
+		 * and the marker list via `checkview_anti_bot_validation_markers`, so
+		 * customers/integrators can add patterns specific to their stack (e.g.,
+		 * non-English error messages or niche anti-spam plugins) without
+		 * modifying the plugin.
 		 *
 		 * @param object $field GF field with `failed_validation` set.
 		 * @return bool
 		 */
 		private static function is_anti_bot_failure( $field ): bool {
-			$bypass_types = array( 'captcha', 'hcaptcha', 'turnstile' );
-			if ( in_array( $field->type ?? '', $bypass_types, true ) ) {
+			/**
+			 * Filters the GF field types treated as anti-bot/captcha during
+			 * CheckView tests. Failures on these field types are always
+			 * cleared. Default: captcha, hcaptcha, turnstile, honeypot.
+			 *
+			 * @since 2.0.36
+			 *
+			 * @param string[] $types Lowercase GF field-type identifiers.
+			 */
+			$bypass_types = apply_filters(
+				'checkview_anti_bot_field_types',
+				array( 'captcha', 'hcaptcha', 'turnstile', 'honeypot' )
+			);
+			if ( in_array( $field->type ?? '', (array) $bypass_types, true ) ) {
 				return true;
 			}
 
@@ -324,19 +342,39 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 				return false;
 			}
 
-			$bypass_markers = array(
-				'captcha',
-				'recaptcha',
-				'turnstile',
-				'are you human',
-				'verify you are human',
-				'verify you are not a robot',
-				'bot detection',
-				'anti-spam',
-				'akismet',
+			/**
+			 * Filters substring patterns (lowercase) matched against a field's
+			 * `validation_message` to detect anti-bot/anti-spam failures during
+			 * CheckView tests. Failures whose message contains any of these
+			 * substrings are cleared. Add your plugin/locale-specific markers
+			 * here (e.g., translated reCAPTCHA messages, niche anti-spam
+			 * plugins).
+			 *
+			 * @since 2.0.36
+			 *
+			 * @param string[] $markers Lowercase substring patterns.
+			 */
+			$bypass_markers = apply_filters(
+				'checkview_anti_bot_validation_markers',
+				array(
+					'captcha',
+					'recaptcha',
+					'turnstile',
+					'verify that you are human', // Simple Cloudflare Turnstile (>100k installs)
+					'verify you are human',
+					'verify you are not a robot',
+					'are you human',
+					'bot detection',
+					'anti-spam',
+					'akismet',
+					'cleantalk',
+					'spam detected',
+					'oopspam',
+					'maspik',
+				)
 			);
-			foreach ( $bypass_markers as $marker ) {
-				if ( false !== strpos( $message, $marker ) ) {
+			foreach ( (array) $bypass_markers as $marker ) {
+				if ( is_string( $marker ) && '' !== $marker && false !== strpos( $message, $marker ) ) {
 					return true;
 				}
 			}

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -405,8 +405,6 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 					'are you human',
 					'verify you are not a robot',
 					'bot detection',
-					'anti-spam',
-					'akismet',
 					// Maspik's default error string (the plugin slug itself
 					// never appears in the user-facing message).
 					'looks like spam',

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -427,11 +427,21 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		 *
 		 * The add-on (slug `gravityformsrecaptcha`, class `GF_RECAPTCHA`)
 		 * hooks both `gform_validation` (response token check) and
-		 * `gform_entry_is_spam` (low-score → spam) at default priority. Both
-		 * are removed here. Wider category-level filters (`gform_entry_is_spam`
-		 * → `__return_false`, marker-bypass in `checkview_bypass_captcha_validation`)
-		 * still catch the case where the class can't be found — e.g., a
-		 * future rename or a fork.
+		 * `gform_entry_is_spam` (low-score → spam) at default priority 10.
+		 *
+		 * Complements `remove_gravityforms_recaptcha_addon()` in
+		 * `includes/checkview-helper-functions.php`, which removes the
+		 * add-on's bootstrap from `gform_loaded` on the initial GET request
+		 * (when `$_REQUEST['checkview_test_id']` is present). That early
+		 * path doesn't fire on the AJAX form submission, where `test_id`
+		 * is only in the cookie/referer; by then the add-on has loaded
+		 * normally and we need to remove its callbacks at runtime instead.
+		 *
+		 * Wider category-level filters (`gform_entry_is_spam`
+		 * → `__return_false`, marker-bypass in
+		 * `checkview_bypass_captcha_validation`) still catch the case
+		 * where the class can't be found — e.g., a future rename or a
+		 * fork.
 		 *
 		 * Hooked at `gform_pre_validation` priority 1 so the unhook happens
 		 * before any `gform_validation` callback fires. Returns the form
@@ -452,18 +462,30 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 				return $form;
 			}
 
+			// Pass priority 10 explicitly — the add-on registers both
+			// callbacks at default priority, and remove_filter must match
+			// the registered priority. If the add-on bumps the priority
+			// in a future release this will silently no-op and the
+			// marker-bypass fallback in checkview_bypass_captcha_validation
+			// picks up the slack.
 			$removed = 0;
 			if ( method_exists( $instance, 'validate_submission' )
-				&& remove_filter( 'gform_validation', array( $instance, 'validate_submission' ) ) ) {
+				&& remove_filter( 'gform_validation', array( $instance, 'validate_submission' ), 10 ) ) {
 				$removed++;
 			}
 			if ( method_exists( $instance, 'check_for_spam_entry' )
-				&& remove_filter( 'gform_entry_is_spam', array( $instance, 'check_for_spam_entry' ) ) ) {
+				&& remove_filter( 'gform_entry_is_spam', array( $instance, 'check_for_spam_entry' ), 10 ) ) {
 				$removed++;
 			}
 
 			if ( $removed > 0 ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Unhooked [' . $removed . '] GF reCAPTCHA Add-On callback(s).' );
+			} else {
+				// Class is present but neither expected callback was
+				// removable. Most likely the add-on renamed its methods
+				// or changed its priority — flag for support so we know
+				// our shim has drifted from the add-on's internals.
+				Checkview_Admin_Logs::add( 'ip-logs', 'GF reCAPTCHA Add-On detected but no callbacks were unhooked (renamed methods or priority changed?) — marker-bypass fallback still active.' );
 			}
 
 			return $form;

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -410,11 +410,6 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 					// Maspik's default error string (the plugin slug itself
 					// never appears in the user-facing message).
 					'looks like spam',
-					// Gravity Wiz GP Blocklist default message
-					// ("This field contains a disallowed term.") and any
-					// custom blocklist-style messages.
-					'blocklist',
-					'disallowed',
 				)
 			);
 			foreach ( (array) $bypass_markers as $marker ) {

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -394,30 +394,29 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 			 */
 			$bypass_markers = apply_filters(
 				'checkview_anti_bot_validation_markers',
+				// Each marker must be verified against a specific source
+				// file + line in the plugin emitting the validation_message
+				// default. Markers added without that verification have
+				// been wrong four times in this PR's history. If you can't
+				// cite source:line, don't add the marker — customers can
+				// extend via the `checkview_anti_bot_validation_markers`
+				// filter for their specific stack.
 				array(
-					// GF core `GF_Field_CAPTCHA` (Really Simple CAPTCHA / math
-					// captcha) default message contains "CAPTCHA". Separate
-					// from the GF reCAPTCHA Add-On (covered by the explicit
-					// `unhook_gf_recaptcha_addon()` runtime unhook).
+					// GF core `GF_Field_CAPTCHA` (Really Simple CAPTCHA /
+					// math captcha): "The CAPTCHA wasn't entered correctly…"
+					// Source: gravityforms/includes/fields/class-gf-field-captcha.php:216,252
 					'captcha',
-					// GF reCAPTCHA Add-On default messages (e.g. "The
-					// reCAPTCHA was invalid…") — defense-in-depth alongside
-					// the runtime unhook.
+					// GF reCAPTCHA Add-On default: "The reCAPTCHA was invalid…"
+					// Source: gravityforms/includes/fields/class-gf-field-captcha.php:293
+					// (defense-in-depth alongside `unhook_gf_recaptcha_addon()`)
 					'recaptcha',
-					// Cloudflare Turnstile field-type error messages.
-					'turnstile',
 					// Simple Cloudflare Turnstile default: "Please verify
-					// that you are human." `are you human` is a substring,
-					// so longer phrasings would be redundant via the
-					// first-match exit.
+					// that you are human." `are you human` is a substring.
+					// Source: simple-cloudflare-turnstile/inc/errors.php:95
 					'are you human',
-					// ALTCHA Spam Protection (10k+ installs) GF field
-					// integration emits `"Could not verify you are not a
-					// robot."` from `validate()`.
-					'verify you are not a robot',
-					// Maspik default ("This looks like spam. Try to
-					// rephrase…"). The plugin slug never appears in the
-					// user-facing message — match on the phrase instead.
+					// Maspik default: "This looks like spam. Try to rephrase…"
+					// The plugin slug never appears in the user-facing message.
+					// Source: contact-forms-anti-spam/includes/functions.php:1281
 					'looks like spam',
 				)
 			);

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -105,6 +105,46 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 					array( $this, 'unhook_gf_recaptcha_addon' ),
 					1
 				);
+
+				// CleanTalk Spam Protect bypass.
+				//
+				// CleanTalk's GF integration registers a callback on
+				// `gform_entry_is_spam`. When the verdict is spam it
+				// ALSO calls `GFFormsModel::delete_lead( $entry['id'] )`
+				// inline — bypassing every WP filter we hook, so the
+				// existing `gform_entry_is_spam` → `__return_false` at
+				// PHP_INT_MAX cannot save the entry from being deleted.
+				//
+				// CleanTalk itself uses the `$cleantalk_executed` global
+				// as an "already handled, don't re-check" sentinel after
+				// successful base API calls. Setting it truthy here causes
+				// `apbct_form__gravityForms__isSkippedRequest()` to return
+				// true, which causes `testSpam()` to return the unmodified
+				// `$is_spam` without calling the API or `delete_lead()`.
+				//
+				// Sources (cleantalk-spam-protect plugin, wp.org trunk):
+				//   - inc/cleantalk-public-integrations.php ~L3148-3180
+				//     (`apbct_form__gravityForms__isSkippedRequest()`
+				//     reads `$cleantalk_executed`)
+				//   - inc/cleantalk-public-integrations.php ~L3058-3068
+				//     (`apbct_form__gravityForms__testSpam()` calls
+				//     `isSkippedRequest()` first)
+				//   - inc/cleantalk-public-validate.php L311-313
+				//     (CleanTalk sets the global itself after API calls)
+				//
+				// CAVEAT: this is an INTERNAL global, not a documented
+				// public API. CleanTalk could rename/remove it in any
+				// release. Harmless if CleanTalk isn't installed (just
+				// creates an unused global). Re-verify on plugin updates
+				// — if the sentinel goes away, fall back to
+				// `remove_filter('gform_entry_is_spam', ...)` on the
+				// add-on's callback.
+				global $cleantalk_executed;
+				$cleantalk_executed = true;
+				Checkview_Admin_Logs::add(
+					'ip-logs',
+					'Set $cleantalk_executed = true to bypass CleanTalk Spam Protect during test (if installed).'
+				);
 			}
 			// Disable addons found in forms.
 			add_filter(

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -247,6 +247,13 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		 * it cannot catch this. This filter runs at PHP_INT_MAX priority
 		 * (guaranteed last, after all other validation hooks) and clears failures.
 		 *
+		 * Scoped to anti-bot fields only: clearing every failure regardless of
+		 * cause was masking real test-flow gaps (e.g. a customer adds a required
+		 * dropdown but the saved test flow has no step to fill it — the test
+		 * would silently "pass" instead of failing honestly). Non-anti-bot
+		 * failures (required fields, format errors, etc.) are kept so they
+		 * surface as real test failures.
+		 *
 		 * Only loaded when is_bot() is true (constructor gated by
 		 * checkview_init_current_test which requires is_bot()).
 		 *
@@ -254,24 +261,87 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		 * @return array
 		 */
 		public function checkview_bypass_captcha_validation( $validation_result ) {
-			if ( ! $validation_result['is_valid'] ) {
-				Checkview_Admin_Logs::add( 'ip-logs',
-					'Form validation failed during CheckView test. Clearing validation failures.' );
+			if ( $validation_result['is_valid'] ) {
+				return $validation_result;
+			}
 
-				$fields = $validation_result['form']['fields'] ?? array();
-				foreach ( $fields as &$field ) {
-					if ( $field->failed_validation ) {
-						Checkview_Admin_Logs::add( 'ip-logs',
-							'Cleared validation failure for field [' . $field->id . '] type [' . $field->type . '].' );
-						$field->failed_validation  = false;
-						$field->validation_message = '';
-					}
+			Checkview_Admin_Logs::add( 'ip-logs',
+				'Form validation failed during CheckView test. Evaluating which failures to clear.' );
+
+			$fields = $validation_result['form']['fields'] ?? array();
+			$remaining_failures = 0;
+
+			foreach ( $fields as &$field ) {
+				if ( empty( $field->failed_validation ) ) {
+					continue;
 				}
 
+				if ( self::is_anti_bot_failure( $field ) ) {
+					Checkview_Admin_Logs::add( 'ip-logs',
+						'Cleared anti-bot validation failure for field [' . $field->id . '] type [' . $field->type . '].' );
+					$field->failed_validation  = false;
+					$field->validation_message = '';
+					continue;
+				}
+
+				$remaining_failures++;
+				Checkview_Admin_Logs::add( 'ip-logs',
+					'Kept validation failure for non-anti-bot field [' . $field->id . '] type [' . $field->type . '] message [' . substr( (string) ( $field->validation_message ?? '' ), 0, 200 ) . '].' );
+			}
+			unset( $field );
+
+			// Only mark the form valid if every remaining failure was anti-bot related.
+			// Otherwise let GF surface the genuine failure so the test fails honestly.
+			if ( 0 === $remaining_failures ) {
 				$validation_result['is_valid'] = true;
+			} else {
+				Checkview_Admin_Logs::add( 'ip-logs',
+					'Form still has [' . $remaining_failures . '] non-anti-bot validation failure(s); not marking as valid.' );
 			}
 
 			return $validation_result;
+		}
+
+		/**
+		 * Determines whether a field's validation failure is anti-bot/captcha related.
+		 *
+		 * Matches by field type (`captcha`, `hcaptcha`, `turnstile`) or by validation
+		 * message pattern — the GF reCAPTCHA Add-On v2.x and similar anti-bot validators
+		 * attach their failure to ordinary fields (often a hidden text or form-level
+		 * marker) rather than a captcha-type field.
+		 *
+		 * @param object $field GF field with `failed_validation` set.
+		 * @return bool
+		 */
+		private static function is_anti_bot_failure( $field ): bool {
+			$bypass_types = array( 'captcha', 'hcaptcha', 'turnstile' );
+			if ( in_array( $field->type ?? '', $bypass_types, true ) ) {
+				return true;
+			}
+
+			$message = strtolower( (string) ( $field->validation_message ?? '' ) );
+			if ( '' === $message ) {
+				return false;
+			}
+
+			$bypass_markers = array(
+				'captcha',
+				'recaptcha',
+				'turnstile',
+				'are you human',
+				'verify you are human',
+				'verify you are not a robot',
+				'bot detection',
+				'anti-spam',
+				'akismet',
+			);
+			foreach ( $bypass_markers as $marker ) {
+				if ( false !== strpos( $message, $marker ) ) {
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		/**

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -224,7 +224,14 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		public function maybe_hide_recaptcha( $form ) {
 			$fields = $form['fields'];
 
-			$spam_field_types = array( 'captcha', 'hcaptcha', 'turnstile', 'honeypot' );
+			// Same allowlist as is_anti_bot_failure() so customers extending
+			// `checkview_anti_bot_field_types` get consistent treatment: a
+			// custom type is removed pre-validation AND its failures are
+			// cleared post-validation.
+			$spam_field_types = (array) apply_filters(
+				'checkview_anti_bot_field_types',
+				array( 'captcha', 'hcaptcha', 'turnstile', 'honeypot' )
+			);
 
 			foreach ( $form['fields'] as $key => $field ) {
 				if ( in_array( $field->type, $spam_field_types, true ) ) {
@@ -325,7 +332,14 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 			 * CheckView tests. Failures on these field types are always
 			 * cleared. Default: captcha, hcaptcha, turnstile, honeypot.
 			 *
-			 * @since 2.0.36
+			 * Note: GF's native honeypot field doesn't normally trip
+			 * `gform_validation` (it uses gform_entry_is_spam + the
+			 * abort path, both covered elsewhere in this class). The
+			 * `honeypot` entry here is harmless defense-in-depth for
+			 * third-party plugins that use the type but route through
+			 * gform_validation.
+			 *
+			 * @since 2.0.35
 			 *
 			 * @param string[] $types Lowercase GF field-type identifiers.
 			 */
@@ -350,7 +364,14 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 			 * here (e.g., translated reCAPTCHA messages, niche anti-spam
 			 * plugins).
 			 *
-			 * @since 2.0.36
+			 * The default list covers plugins that surface their failure via
+			 * a field's `validation_message`. Plugins that flag submissions
+			 * via `gform_entry_is_spam` instead (CleanTalk, OOPSpam, Akismet,
+			 * native GF Honeypot, etc.) are handled by the existing
+			 * `gform_entry_is_spam` → `__return_false` filter in the
+			 * constructor — not by this list.
+			 *
+			 * @since 2.0.35
 			 *
 			 * @param string[] $markers Lowercase substring patterns.
 			 */
@@ -360,17 +381,18 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 					'captcha',
 					'recaptcha',
 					'turnstile',
-					'verify that you are human', // Simple Cloudflare Turnstile (>100k installs)
-					'verify you are human',
-					'verify you are not a robot',
+					// Note: `are you human` is a substring of common Cloudflare
+					// Turnstile and reCAPTCHA messages ("Please verify that you
+					// are human"), so the loop's first-match exit makes the
+					// longer phrasings redundant.
 					'are you human',
+					'verify you are not a robot',
 					'bot detection',
 					'anti-spam',
 					'akismet',
-					'cleantalk',
-					'spam detected',
-					'oopspam',
-					'maspik',
+					// Maspik's default error string (the plugin slug itself
+					// never appears in the user-facing message).
+					'looks like spam',
 				)
 			);
 			foreach ( (array) $bypass_markers as $marker ) {

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -356,6 +356,15 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 			 * third-party plugins that use the type but route through
 			 * gform_validation.
 			 *
+			 * WARNING: this filter is consumed by TWO independent layers
+			 * — `maybe_hide_recaptcha()` (strips fields of these types
+			 * pre-validation) AND `is_anti_bot_failure()` (clears their
+			 * failures post-validation). Returning an empty array or
+			 * `null` disables BOTH layers, not just one. Use the
+			 * `checkview_anti_bot_validation_markers` filter for
+			 * message-based extensions instead of weakening this
+			 * type list.
+			 *
 			 * @since 2.0.35
 			 *
 			 * @param string[] $types Lowercase GF field-type identifiers.


### PR DESCRIPTION
## Summary

- Scopes `Checkview_Gforms_Helper::checkview_bypass_captcha_validation()` so it only clears anti-bot/captcha failures, not every failed-validation flag in the form. Required-field failures, format errors, and custom validation messages now surface honestly so tests fail with the real reason when a test flow is missing a step
- Adds an **explicit unhook for the GF reCAPTCHA Add-On v2.x** (the original 2022 motivation for the broad bypass) — surgical, doesn't rely on substring matching
- Adds a **bootstrap removal for the GF Cloudflare Turnstile Add-On**, mirroring the existing reCAPTCHA bootstrap removal
- Adds two extension filters so customers/integrators can extend the detection lists without forking the plugin
- ClickUp: [868jqu876](https://app.clickup.com/t/868jqu876) (primary), [868jtdwg6](https://app.clickup.com/t/868jtdwg6) (Turnstile follow-up, folded in here)

## The problem

The original hook was a sledgehammer:

```php
foreach ( $fields as &$field ) {
    if ( $field->failed_validation ) {
        // CLEAR EVERY FAILURE, REGARDLESS OF CAUSE
        $field->failed_validation  = false;
        $field->validation_message = '';
    }
}
$validation_result['is_valid'] = true;
```

The 2022 code comment said the intent was to bypass the **GF reCAPTCHA Add-On v2.x** (which validates via `gform_validation` and doesn't use a `captcha`-type field). The implementation cleared every kind of failure: required fields, format errors, conditional logic, custom validation, etc.

Real-world impact (rubberduckers.co.uk, 5/22): customer added a required "Enquiry type" dropdown, saved test flow had no step to fill it, server-side helper cleared the failure, client-side JS blocked the submit click, test failed at `assert_form_submitted` with no useful signal. 30+ minutes of debugging to identify the missing step.

This has been silently bypassing required-field validation in customer tests for **~3 years**. Most customers never noticed because (a) tests usually do fill all required fields, (b) the entry got created server-side so `assert_form_submitted` passed.

## Architecture: layered defense

| Layer | What it does | Plugins covered |
|---|---|---|
| **Bootstrap removal on `gform_loaded`** | Prevents the add-on from loading at all on the initial GET (when `$_REQUEST['checkview_test_id']` is set) | Pre-existing: GF reCAPTCHA Add-On bootstrap. NEW: GF Cloudflare Turnstile Add-On bootstrap |
| **Runtime per-plugin unhook** | Removes plugin callbacks at AJAX submission time (where `test_id` is in cookie/referer, not `$_REQUEST`) | Pre-existing: Simple Cloudflare Turnstile (`cfturnstile_whitelisted`), hCaptcha (`hcap_activate`), Akismet (`akismet_get_api_key`), GF Zero Spam, GF native honeypot (`gform_abort_submission_with_confirmation` + `gform_entry_is_spam`). **NEW**: GF reCAPTCHA Add-On runtime unhook of `validate_submission` + `check_for_spam_entry` |
| **Field-type allowlist** | Removes captcha-shaped fields from the form before validation (`maybe_hide_recaptcha`) and clears their failures post-validation (`is_anti_bot_failure`) | First-class `captcha` / `hcaptcha` / `turnstile` / `honeypot` field types — including `GF_Field_Turnstile` which is where the Cloudflare Turnstile Add-On actually validates |
| **Marker-bypass safety net** (the function this PR scopes) | Substring-matches `validation_message` against known anti-bot phrases | Maspik, translated/unknown reCAPTCHA-style errors, future anti-bot plugins we haven't explicitly handled |
| **Filter-based customer escape hatch** | `checkview_anti_bot_field_types` + `checkview_anti_bot_validation_markers` | Anything the customer or integrator needs to add (locale, niche plugin) |

The five layers compose: bootstrap and runtime unhooks are the primary defense, the marker bypass is the residual safety net for unknowns, the filters let customers fix gaps without a plugin update.

## The fix

**1. Scoped bypass.** `checkview_bypass_captcha_validation()` now only clears failures matching either:
- Field type allowlist: `captcha`, `hcaptcha`, `turnstile`, `honeypot`
- Validation message substring (case-insensitive), each verified against a specific `source:line` in the plugin emitting the default:
  - `captcha` — GF core `GF_Field_CAPTCHA`: "The CAPTCHA wasn't entered correctly…" (`gravityforms/includes/fields/class-gf-field-captcha.php:216,252`)
  - `recaptcha` — GF reCAPTCHA Add-On: "The reCAPTCHA was invalid…" (`gravityforms/includes/fields/class-gf-field-captcha.php:293`)
  - `are you human` — Simple Cloudflare Turnstile: "Please verify that you are human." (`simple-cloudflare-turnstile/inc/errors.php:95`)
  - `looks like spam` — Maspik: "This looks like spam. Try to rephrase…" (`contact-forms-anti-spam/includes/functions.php:1281`)

  Note: Akismet, CleanTalk, OOPSpam etc. are NOT in this list — they route via `gform_entry_is_spam` (already covered by `__return_false` filter), not field validation_message

`is_valid` only flips to `true` if every remaining failed-validation field was cleared. Otherwise GF surfaces the real error and the test fails honestly.

**2. Explicit GF reCAPTCHA Add-On runtime unhook.** New `unhook_gf_recaptcha_addon()` runs on `gform_pre_validation` priority 1. Resolves `GF_RECAPTCHA::get_instance()` and removes:
- `validate_submission` from `gform_validation` (explicit priority 10)
- `check_for_spam_entry` from `gform_entry_is_spam` (explicit priority 10)

Defensive: `class_exists`/`is_callable`/`is_object`/`method_exists` checks throughout. Logs the count of unhooked callbacks; logs a distinct "detected but couldn't unhook" branch so support can spot a future rename of the add-on's internals before customers report failures.

**3. GF Cloudflare Turnstile Add-On bootstrap removal.** New `remove_gravityforms_turnstile_addon()` in `includes/checkview-helper-functions.php`, sibling of the existing `remove_gravityforms_recaptcha_addon()`. Removes `GF_Turnstile_Bootstrap::load` from `gform_loaded` priority 5 so the add-on doesn't initialise during a test.

**Note on the asymmetric handling**: the Cloudflare Turnstile Add-On's token validation lives on the **field class** (`GF_Field_Turnstile::validate`), not on a `gform_validation` filter. The add-on's own `gform_validation` hook just repositions the field. So a runtime `remove_filter` sibling like reCAPTCHA's isn't needed — the field-level validation is independently covered by `maybe_hide_recaptcha()` stripping `turnstile`-typed fields and the `turnstile` type in the allowlist.

**4. Extension filters.** `checkview_anti_bot_field_types` + `checkview_anti_bot_validation_markers`. `maybe_hide_recaptcha()` also reads `checkview_anti_bot_field_types` so a customer extending the filter gets both treatments consistently (no footgun).

**5. Logging differentiated.**
- `Cleared anti-bot validation failure for field [N] type [T].`
- `Kept validation failure for non-anti-bot field [N] type [T] message [...].`
- `Form still has [N] non-anti-bot validation failure(s); not marking as valid.`
- `Unhooked [N] GF reCAPTCHA Add-On callback(s).`
- `GF reCAPTCHA Add-On detected but no callbacks were unhooked (renamed methods or priority changed?) — marker-bypass fallback still active.`

## Other form helpers — already handled

For the question "do we need to do this for CF7 / Fluent / NF / WPForms / Formidable / Forminator / WS Form / Everest?" — **no**. Each of those helpers already uses per-plugin unhooks tailored to its ecosystem:

| Helper | Per-plugin unhooks |
|---|---|
| CF7 | `wpcf7_spam`, `wpcf7_skip_spam_check`, `cfturnstile_whitelisted`, `akismet_get_api_key` |
| Fluent Forms | `fluentform/has_recaptcha`, `has_hcaptcha`, `has_turnstile`, `akismet_check_spam`, `cfturnstile_whitelisted`, `akismet_get_api_key` |
| Ninja Forms | `akismet_get_api_key`, `cfturnstile_whitelisted`, `ninja_forms_action_recaptcha__verify_response`, type-based field removal |
| WPForms | `wpforms_frontend_recaptcha_disable` (true), `wpforms_process_bypass_captcha`, `cfturnstile_whitelisted`, `akismet_get_api_key`, frontend captcha API disable |
| Formidable | `remove_recaptcha_field_from_list`, `akismet_get_api_key`, `cfturnstile_whitelisted`, `frm_run_honeypot` |
| Forminator | `akismet_get_api_key`, `forminator_spam_protection`, `cfturnstile_whitelisted`, `forminator_invalid_captcha_message` |
| WS Form | `akismet_get_api_key`, `cfturnstile_whitelisted`, type-based field removal |
| Everest Forms | `everest_forms_recaptcha_disabled`, recaptcha action removal, empties recaptcha keys |

None of those helpers have a marker-based `gform_validation`-style bypass — they use each form plugin's own documented filter API. The marker bypass is unique to the GF helper because GF has the richest anti-bot extension surface via `gform_validation`. Other form helpers don't need similar work.

## Extension example

```php
add_filter( 'checkview_anti_bot_field_types', function ( $types ) {
    $types[] = 'my_custom_captcha_field_type';
    return $types;
} );

add_filter( 'checkview_anti_bot_validation_markers', function ( $markers ) {
    // Translated reCAPTCHA error in French
    $markers[] = 'veuillez vérifier que vous êtes humain';
    return $markers;
} );
```

## Behavior change

Sites whose tests previously passed **only** because the loose bypass was clearing a required-field failure will start failing after this lands. That's the intended outcome — those tests were passing dishonestly. The fix is a `regenerate` on the affected test flow so the new field gets a step.

Estimated affected population is low single-digit-percent of GF-using customers (mostly sites where the customer added required fields after the test flow was generated and never regenerated).

### Suggested release-note text

> **Gravity Forms: more accurate test failures, plus better Turnstile/reCAPTCHA add-on handling.** Previously, CheckView's GF helper cleared every validation failure during a test, which could mask required fields added after the test flow was generated. Tests now fail honestly when a required field isn't filled, with the failing field shown in the helper logs (look for `Kept validation failure for non-anti-bot field`). If a previously-passing test starts failing, regenerate the test flow so it picks up the new field. The official GF reCAPTCHA and Cloudflare Turnstile add-ons are now disabled more precisely during a test instead of relying on substring matches against their error messages. Advanced users can extend the anti-bot detection via two new filters: `checkview_anti_bot_field_types` and `checkview_anti_bot_validation_markers`.

## Test plan

- [ ] **GF reCAPTCHA Add-On v2.x** installed: confirm `Unhooked [N] GF reCAPTCHA Add-On callback(s).` appears in ip-logs and the test passes
- [ ] **GF reCAPTCHA Add-On v2.x** with the `validate_submission` or `check_for_spam_entry` method renamed (or its priority changed) in a future hypothetical version: confirm the `GF reCAPTCHA Add-On detected but no callbacks were unhooked` log line fires and the marker bypass picks up the slack (smoke test by temporarily renaming the method in a dev install). Note: a full **class** rename short-circuits at `class_exists`, returns silently, and is only caught by the marker fallback — that is also acceptable behaviour
- [ ] **GF Cloudflare Turnstile Add-On** installed: confirm the add-on doesn't load on the initial GET request (no Turnstile widget rendered), test passes
- [ ] **First-class `captcha`/`hcaptcha`/`turnstile` field**: still passes (type allowlist + `maybe_hide_recaptcha` strip)
- [ ] **Simple Cloudflare Turnstile** (default error "Please verify that you are human."): still passes — `are you human` substring marker plus pre-existing `cfturnstile_whitelisted=true` short-circuit
- [ ] **Maspik** (default error "This looks like spam. Try to rephrase..."): still passes (`looks like spam` marker)
- [ ] **GravityKit Zero Spam** / **Akismet for GF** / **CleanTalk** / **OOPSpam**: still pass via the existing `gform_entry_is_spam → __return_false` filter
- [ ] **Required field NOT filled** by the test flow: test now fails honestly at `assert_form_submitted` with the real validation message visible in the helper logs
- [ ] **Mixed failure**: form with reCAPTCHA v2 AND a required field both failing simultaneously — confirm partial-clear logic (anti-bot unhooked or cleared, required kept, `is_valid` stays false, test fails)
- [ ] **Conditional-logic-required field**: still fails honestly (not falsely treated as anti-bot)
- [ ] **GF native honeypot** form: double-covered by `gform_entry_is_spam → __return_false` and `gform_abort_submission_with_confirmation → __return_false`. The `honeypot` type allowlist entry is defensive only
- [ ] **`checkview_anti_bot_field_types` filter**: adding a custom type extends the allowlist AND that the same custom type is removed by `maybe_hide_recaptcha()` (no footgun)
- [ ] **`checkview_anti_bot_validation_markers` filter**: adding a custom marker extends the list correctly
- [ ] **Misconfigured filter** returning a non-array or array of non-strings: no fatal — defensive guards handle it
- [ ] **`quality`-branch soak**: deploy to `quality` for one release cycle, sample 20+ fleet sites' helper logs for `Kept validation failure for non-anti-bot field` lines to identify customers who need to regenerate test flows BEFORE promoting to `main`

## Related

- [#211](https://github.com/CheckView/helper/pull/211) — sibling PR fixing GF 2.10 Background Notifications recipient leak. Same investigation found both.
- ClickUp [868jqu876](https://app.clickup.com/t/868jqu876) — primary
- ClickUp [868jtdwg6](https://app.clickup.com/t/868jtdwg6) — Turnstile follow-up, closed and folded in here
- ClickUp [868jte6xv](https://app.clickup.com/t/868jte6xv) — `$_GET` tightening on the extracted helper (follow-up commit 4f96ef8)


🤖 Generated with [Claude Code](https://claude.com/claude-code)






