### PR TITLE
Fix cv_entry_meta silent insert failures from oversized meta_key values

### DIFF
--- a/includes/checkview-functions.php
+++ b/includes/checkview-functions.php
@@ -1749,11 +1749,44 @@ if ( ! function_exists( 'checkview_truncate_for_cv_entry' ) ) {
 	 * @return array Row with overflowing string fields truncated.
 	 */
 	function checkview_truncate_for_cv_entry( array $row ) {
+		$has_mb = function_exists( 'mb_substr' );
 		foreach ( checkview_get_cv_entry_string_limits() as $col => $max ) {
 			if ( isset( $row[ $col ] ) && is_string( $row[ $col ] ) ) {
-				$row[ $col ] = substr( $row[ $col ], 0, $max );
+				$row[ $col ] = $has_mb
+					? mb_substr( $row[ $col ], 0, $max, 'UTF-8' )
+					: substr( $row[ $col ], 0, $max );
 			}
 		}
 		return $row;
+	}
+}
+
+if ( ! function_exists( 'checkview_truncate_meta_key' ) ) {
+	/**
+	 * Truncates a cv_entry_meta meta_key to the schema's varchar(255) limit.
+	 *
+	 * Mirrors checkview_truncate_for_cv_entry() but targets the separate
+	 * cv_entry_meta.meta_key column declared in
+	 * Checkview_Activator::checkview_run_sql() (varchar(255)). Sources are
+	 * unbounded plugin-side strings — CF7 raw POST keys, Fluent Forms
+	 * field_name + sub_field_name, Forminator $field['name'], WS Form
+	 * prefix + wsf_submit_meta.meta_key, Everest sanitize_key result —
+	 * which can exceed 255 chars and silently fail the insert.
+	 *
+	 * Uses mb_substr (character-based) to match MySQL's utf8mb4 char-counting
+	 * and avoid cutting mid-codepoint. Byte-based substr() would produce
+	 * invalid UTF-8 that wpdb::process_field_lengths() then rejects with the
+	 * same silent-failure mode this helper is meant to prevent.
+	 *
+	 * @param mixed $key The composed meta_key. Non-string values pass through unchanged.
+	 * @return mixed Truncated string, or original value if not a string.
+	 */
+	function checkview_truncate_meta_key( $key ) {
+		if ( ! is_string( $key ) ) {
+			return $key;
+		}
+		return function_exists( 'mb_substr' )
+			? mb_substr( $key, 0, 255, 'UTF-8' )
+			: substr( $key, 0, 255 );
 	}
 }

--- a/includes/formhelpers/class-checkview-cf7-helper.php
+++ b/includes/formhelpers/class-checkview-cf7-helper.php
@@ -375,16 +375,11 @@ if ( ! class_exists( 'Checkview_Cf7_Helper' ) ) {
 				$count = 0;
 
 				foreach ( $form_data as $key => $val ) {
-					// CF7 field `name` attributes are raw POST keys, not
-					// constrained to any length by CF7 itself. cv_entry_meta.meta_key
-					// is varchar(255), so an unusually long form-field name would
-					// otherwise overflow and fail wpdb::process_field_lengths().
-					$meta_key = is_string( $key ) ? substr( $key, 0, 255 ) : $key;
 					$entry_metadata = array(
 						'uid' => $checkview_test_id,
 						'form_id' => $form_id,
 						'entry_id' => $inserted_entry_id,
-						'meta_key' => $meta_key,
+						'meta_key' => checkview_truncate_meta_key( $key ),
 						'meta_value' => $val,
 					);
 

--- a/includes/formhelpers/class-checkview-everest-forms-helper.php
+++ b/includes/formhelpers/class-checkview-everest-forms-helper.php
@@ -281,7 +281,7 @@ if ( ! class_exists( 'Checkview_Everest_Forms_Helper' ) ) {
 						'uid'        => $checkview_test_id,
 						'form_id'    => $form_id,
 						'entry_id'   => $entry_id,
-						'meta_key'   => 'evf_' . sanitize_key( $field['meta_key'] ),
+						'meta_key'   => checkview_truncate_meta_key( 'evf_' . sanitize_key( $field['meta_key'] ) ),
 						'meta_value' => maybe_serialize( $field['value'] ),
 					);
 

--- a/includes/formhelpers/class-checkview-fluent-forms-helper.php
+++ b/includes/formhelpers/class-checkview-fluent-forms-helper.php
@@ -308,7 +308,7 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 					'uid'        => $checkview_test_id,
 					'form_id'    => $form_id,
 					'entry_id'   => $row->submission_id,
-					'meta_key'   => $meta_key,
+					'meta_key'   => checkview_truncate_meta_key( $meta_key ),
 					'meta_value' => $row->field_value,
 				);
 

--- a/includes/formhelpers/class-checkview-forminator-helper.php
+++ b/includes/formhelpers/class-checkview-forminator-helper.php
@@ -208,7 +208,7 @@ if ( ! class_exists( 'Checkview_Forminator_Helper' ) ) {
 					'uid'        => $checkview_test_id,
 					'form_id'    => $form_id,
 					'entry_id'   => $entry_id,
-					'meta_key'   => $meta_key,
+					'meta_key'   => checkview_truncate_meta_key( $meta_key ),
 					'meta_value' => $field_value,
 				);
 

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -430,7 +430,7 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 					'uid' => $uid,
 					'form_id' => $row->form_id,
 					'entry_id' => $row->entry_id,
-					'meta_key' => $row->meta_key,
+					'meta_key' => checkview_truncate_meta_key( $row->meta_key ),
 					'meta_value' => $row->meta_value,
 				);
 

--- a/includes/formhelpers/class-checkview-wsf-helper.php
+++ b/includes/formhelpers/class-checkview-wsf-helper.php
@@ -231,7 +231,7 @@ if ( ! class_exists( 'Checkview_WSF_Helper' ) ) {
 						'uid' => $checkview_test_id,
 						'form_id' => $form_id,
 						'entry_id' => $entry_id,
-						'meta_key' => $field_id_prefix . str_replace( '_', '-', $field->meta_key ),
+						'meta_key' => checkview_truncate_meta_key( $field_id_prefix . str_replace( '_', '-', $field->meta_key ) ),
 						'meta_value' => $field->meta_value,
 					);
 


### PR DESCRIPTION
## Summary
Prevents silent `cv_entry_meta` insert failures when composed `meta_key` values exceed varchar(255).

## Why
Per the wpdb silent-failure playbook: when `meta_key` overflows, `wpdb::process_field_lengths()` rejects the row and `wpdb::insert()` returns false — with PR #206's logging in place, you now see `Failed to clone submission entry meta data. wpdb->last_error=[Data too long for column 'meta_key' at row 1]`.

Original ticket ([CU 868jnfpcp](https://app.clickup.com/t/868jnfpcp)) flagged Fluent Forms; full audit of all 9 form helpers found the same exposure in **5 more places**:

| Helper | Source | Risk |
|---|---|---|
| Fluent | `'ff_' + form_id + '_' + field_name(varchar 255) + '_' + sub_field_name(varchar 255) + '_'` | up to ~520 chars (ticket bug) |
| Forminator | raw `$field['name']` | unbounded |
| WS Form | `'wsf' + str_replace($field->meta_key)` (varchar 255 source) | up to 258 chars |
| Everest | `'evf_' + sanitize_key($field['meta_key'])` (length not capped) | unbounded |
| GF | direct `$row->meta_key` copy | varchar(255) exact, no headroom — defensive |

Safe by construction (untouched): Ninja Forms (`'nf-field-' + int`), WPForms (`prefix + int + suffix`), Formidable (`int field_id`).

## What changed
- New `checkview_truncate_meta_key()` in `includes/checkview-functions.php` — mirrors `checkview_truncate_for_cv_entry()` but for the cv_entry_meta column.
- 6 form helpers call it at the meta_key assignment site (CF7 refactored from inline `substr`).
- **Drive-by fix**: sibling `checkview_truncate_for_cv_entry()` upgraded from `substr` → `mb_substr` too. Same UTF-8 mid-codepoint hazard for `user_agent`/`payment_method` columns; the byte-based `substr` could cut mid-codepoint and produce invalid UTF-8 that wpdb itself then rejects (exactly the silent-failure mode the helper exists to prevent). One-line fix, same file, same function family — splitting felt like ceremony.

Both helpers guard `mb_substr` with `function_exists()` and fall back to `substr` if mbstring is missing. Matches the vendor precedent in this plugin (`firebase/php-jwt`, `paragonie/sodium_compat`).

## Files
- `includes/checkview-functions.php` (+28)
- 6 form helpers (CF7 refactor + 5 wraps)

## Test plan
- [ ] CF7 submission with a >255-char field name lands in `cv_entry_meta` (was silently dropped pre-PR #206; pre-this-PR would fail again on multibyte field names)
- [ ] Fluent/Forminator/WS Form/Everest/GF submissions still round-trip normally
- [ ] Multibyte field name truncates on character boundary, not mid-codepoint (verify with `é` × 300 or 🌟 × 200)
- [ ] No version bump (per Helper Plugin versioning rule — this is dev-branch fix, not a release)

## Out of scope (flagged for follow-up)
- 6 helpers don't route their `cv_entry` inserts through `checkview_truncate_for_cv_entry()` (only Fluent + GF do) — defense-in-depth opportunity.
- `cv_session` / `cv_used_nonces` writes of internally-generated values are bounded in practice but unguarded.
- `.phpcs.xml.dist` `testVersion="5.6-"` doesn't match plugin's `Requires PHP: 7.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)