### PR TITLE
fix(nonces): log wpdb->last_error on cv_used_nonces insert failure

### DIFF
--- a/includes/API/class-checkview-api.php
+++ b/includes/API/class-checkview-api.php
@@ -2599,10 +2599,11 @@ class CheckView_Api {
 				''
 			);
 		} else {
-			// Store the nonce in the database.
+			// Store the nonce in the database. wpdb::insert() returns false on
+			// failure (not WP_Error), so is_wp_error() would never catch it.
 			$response = $wpdb->insert( $cv_used_nonces, array( 'nonce' => $nonce_token ) );
-			if ( is_wp_error( $response ) ) {
-				Checkview_Admin_Logs::add( 'api-logs', 'Not able to add nonce.' );
+			if ( false === $response ) {
+				Checkview_Admin_Logs::add( 'api-logs', 'Not able to add nonce. wpdb->last_error=[' . $wpdb->last_error . ']' );
 				return new WP_Error(
 					'error',
 					esc_html__(

--- a/includes/checkview-functions.php
+++ b/includes/checkview-functions.php
@@ -1559,10 +1559,11 @@ if ( ! function_exists( 'checkview_get_option_data_handler' ) ) {
 			wp_send_json_error( esc_html__( 'There was a technical error while processing your request.', 'checkview' ) );
 			wp_die();
 		} else {
-			// Store the nonce in the database.
+			// Store the nonce in the database. wpdb::insert() returns false on
+			// failure (not WP_Error), so is_wp_error() would never catch it.
 			$response = $wpdb->insert( $cv_used_nonces, array( 'nonce' => $nonce_token ) );
-			if ( is_wp_error( $response ) ) {
-				Checkview_Admin_Logs::add( 'api-logs', 'Not able to add nonce.' );
+			if ( false === $response ) {
+				Checkview_Admin_Logs::add( 'api-logs', 'Not able to add nonce. wpdb->last_error=[' . $wpdb->last_error . ']' );
 				wp_send_json_error( esc_html__( 'There was a technical error while processing your request.', 'checkview' ) );
 			}
 		}


### PR DESCRIPTION
## Summary
Two latent bugs in the `cv_used_nonces` insert path: failure branch was unreachable (`is_wp_error()` on a `wpdb::insert()` return), and the log entry omitted `$wpdb->last_error`.

## Why
`wpdb::insert()` returns `false` on failure, never a `WP_Error`. The existing `is_wp_error( $response )` guard was dead code — any failed nonce insert was silently swallowed. Completes the diagnostic-parity logging pattern PR #206 established across the 18 cv_entry / cv_entry_meta failure-log sites.

## What changed
- `includes/API/class-checkview-api.php:2604` — REST permission_callback nonce insert: `false === $response` + log `$wpdb->last_error`
- `includes/checkview-functions.php:1564` — AJAX option-data handler nonce insert: same fix
- One-line code comment explains why `is_wp_error()` was wrong (in case the next reader is tempted to copy the pattern)

## Files
- 2 files, +8 / −6 lines

## Test plan
- [ ] Force an insert failure (e.g. simulate a duplicate nonce on the UNIQUE column) — confirm log line includes `wpdb->last_error=[...]`
- [ ] Happy path: nonce stored, no failure log emitted, existing behavior unchanged
- [ ] Existing PHPUnit tests still pass (no test currently exercises the failure path)

Refs ClickUp [868jnfpfw](https://app.clickup.com/t/868jnfpfw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)