### PR TITLE
fix(security): remove hardcoded public bot IPs + harden Woo test gateway

### DIFF
--- a/includes/checkview-functions.php
+++ b/includes/checkview-functions.php
@@ -543,9 +543,14 @@ if ( ! function_exists( 'checkview_get_api_ip' ) ) {
 		}
 
 		if ( is_array( $ip_address ) ) {
+			// Loopback only. Do NOT hardcode public IPs here. This allowlist is
+			// matched against client-supplied forwarding headers (X-Forwarded-For,
+			// etc.) in checkview_get_visitor_ip(), so any hardcoded public IP
+			// becomes a permanent, unauthenticated bypass of CheckView::is_bot()
+			// — and therefore of WooCommerce "test mode" and its $0 checkout
+			// gateway. Trusted bot IPs must come only from the authenticated SaaS
+			// whitelist (verify.checkview.io).
 			$ip_address[] = '::1';
-			$ip_address[] = '188.251.23.194';
-			$ip_address[] = '2001:8a0:e5d0:a900:70a5:138a:d159:5054';
 		}
 
 		return $ip_address;

--- a/includes/woocommercehelper/class-checkview-blocks-payment-gateway.php
+++ b/includes/woocommercehelper/class-checkview-blocks-payment-gateway.php
@@ -48,12 +48,16 @@ final class Checkview_Blocks_Payment_Gateway extends AbstractPaymentMethodType {
 	}
 
 	/**
-	 * Returns true.
+	 * Whether the CheckView block payment method is active.
+	 *
+	 * Defense-in-depth: only expose the $0 block checkout gateway during an
+	 * active CheckView test session, never to a real shopper. Previously this
+	 * returned an unconditional true.
 	 *
 	 * @return boolean
 	 */
 	public function is_active() {
-		return true;
+		return class_exists( 'CheckView' ) && CheckView::is_bot();
 	}
 
 	/**

--- a/includes/woocommercehelper/class-checkview-payment-gateway.php
+++ b/includes/woocommercehelper/class-checkview-payment-gateway.php
@@ -53,6 +53,24 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		}
 
 		/**
+		 * Restricts gateway availability to active CheckView test sessions.
+		 *
+		 * Defense-in-depth: this gateway is only registered while
+		 * CheckView::is_bot() is true, but WooCommerce caches gateway objects and
+		 * re-evaluates availability throughout a request. Re-verify on every
+		 * availability check so the $0 gateway can never surface on a real
+		 * shopper's checkout.
+		 *
+		 * @return bool
+		 */
+		public function is_available() {
+			if ( ! class_exists( 'CheckView' ) || ! CheckView::is_bot() ) {
+				return false;
+			}
+			return parent::is_available();
+		}
+
+		/**
 		 * Displays payment gateway description.
 		 *
 		 * @return void


### PR DESCRIPTION
## Summary

Addresses the Patchstack **Broken Access Control** report (CVSS 7.5) against CheckView Automated Testing `<= 2.1.0`.

An **unauthenticated** visitor could pass `CheckView::is_bot()` by sending a spoofed forwarding header, which enables WooCommerce **"test mode"** and registers a `$0` `checkview` payment gateway — letting them check out **real/downloadable products for free**.

The single load-bearing trick in the published PoC is that `checkview_get_api_ip()` **unconditionally appended two hardcoded public IPs** to the bot allowlist. Because that allowlist is matched against client-supplied forwarding headers (`X-Forwarded-For`, `CF-Connecting-IP`, `Client-IP`, …) in `checkview_get_visitor_ip()` with **no trusted-proxy binding**, those entries were a permanent, world-reachable bypass: `X-Forwarded-For: 188.251.23.194` alone satisfied the IP gate from anywhere.

> Both hardcoded IPs (`188.251.23.194` and the IPv6) whois to a **MEO Broadband dynamic residential range in Portugal** — almost certainly a developer's home IP added for local convenience and never removed. Because the range is dynamic, that address may already belong to an unrelated subscriber.

## Changes

1. **Remove the hardcoded public IPs** from `checkview_get_api_ip()` — keep loopback (`::1`) only, with a comment explaining why public IPs must never be hardcoded here. **This breaks the published PoC**, which depends on the fixed `188.251.23.194`.
2. **Sink defense-in-depth:**
   - `Checkview_Payment_Gateway::is_available()` now re-checks `CheckView::is_bot()` so the `$0` gateway can never surface on a real shopper's checkout.
   - `Checkview_Blocks_Payment_Gateway::is_active()` now returns `is_bot()` instead of an unconditional `true`.

## Scope / what this does NOT fix yet

This PR removes the trivial always-valid backdoor and tightens the sink. It does **not** fully close the access-control design, because two deeper fixes require **coordinated SaaS-side changes** and can't be done plugin-only:

- **Trusted-proxy binding** for forwarded headers. The legitimate bot connects **directly from GCP** (verify.checkview.io/whitelist.json returns GCP egress IPs), so `REMOTE_ADDR` is the real bot IP on direct-connect sites — but Cloudflare/host-fronted customers receive it in `CF-Connecting-IP`, and the plugin has no trusted-proxy config. Shipping a naive `REMOTE_ADDR`-only restriction now would break those customers' tests (form tests too, since they share `is_bot()`), so it's deferred.
- **Server-issued / verified secret `checkview_test_id`.** Today `test_type()` only *format*-validates the UUID; any well-formed UUID works. A real fix requires the SaaS to register the test UUID with the site over the authenticated API first — the API currently never receives the UUID.

Residual risk after this PR: an attacker who learns a real CheckView bot IP (e.g. from a target's access logs) could still spoof it **on sites whose edge does not sanitize inbound forwarding headers**. The follow-up above closes that.

## Testing

- `php -l` clean on all three changed files.
- No version bump (per quality-branch policy).

## Verification checklist for reviewer

- [ ] Run a real WooCommerce `full_checkout` test against a site on this branch and confirm test mode + `$0` gateway still work for the legit bot.
- [ ] Confirm the PoC (`X-Forwarded-For: 188.251.23.194` + `?checkview_test_id=<uuid>&checkview_test_type=full_checkout`) no longer exposes the `checkview` payment method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)