### PR TITLE
fix(security): require signed CheckView requests in is_bot() — PR 2 of 2 [DRAFT]

### DIFF
--- a/includes/class-checkview.php
+++ b/includes/class-checkview.php
@@ -175,8 +175,31 @@ class CheckView {
 		$cv_bot_ip   = checkview_get_api_ip();
 		$is_local    = defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE === 'local';
 		$ip_verified = $is_local || ( is_array( $cv_bot_ip ) && in_array( $visitor_ip, $cv_bot_ip ) );
+
+		// Unforgeable per-request signal: the CheckView test runner attaches a
+		// short-lived signed token (X-CheckView-Signature) that this verifies
+		// cryptographically. Unlike the IP allowlist, it cannot be spoofed via
+		// forwarding headers and survives proxies/CDNs intact.
+		$sig_verified = self::is_request_signed();
+
+		/**
+		 * Filter: when true, a valid CheckView request signature is REQUIRED and
+		 * the (spoofable) IP allowlist is no longer sufficient on its own.
+		 *
+		 * Default false (transitional): a request passes if it carries a valid
+		 * signature OR matches the IP allowlist. This keeps the signature path
+		 * inert until the SaaS is signing every request fleet-wide, so the code
+		 * is safe to ship ahead of the cutover; flip the filter on to enforce.
+		 *
+		 * @since 2.1.1
+		 *
+		 * @param bool $require_signed Whether a valid signature is mandatory.
+		 */
+		$require_signed = (bool) apply_filters( 'checkview_require_signed_request', false );
+		$verified       = $require_signed ? $sig_verified : ( $sig_verified || $ip_verified );
+
 		$test_type = self::test_type();
-		$result = $test_type && $ip_verified;
+		$result = $test_type && $verified;
 
 		// Only log during actual tests
 		if ( isset( $_REQUEST['checkview_test_id'] ) ) {
@@ -216,18 +239,61 @@ class CheckView {
 			$headers[] = 'RA=[' . ( $ra ?: 'not set' ) . ']';
 
 			Checkview_Admin_Logs::add( 'ip-logs', sprintf(
-				'Bot check %s [%s]: detected=[%s], %s, ip_ok=[%s], whitelist=[%d IPs]%s',
+				'Bot check %s [%s]: detected=[%s], %s, ip_ok=[%s], sig_ok=[%s], mode=[%s], whitelist=[%d IPs]%s',
 				$result ? 'PASSED' : 'FAILED',
 				$test_id,
 				$safe_visitor_ip ?: 'empty',
 				implode( ', ', $headers ),
 				$ip_verified ? 'yes' : 'no',
+				$sig_verified ? 'yes' : 'no',
+				$require_signed ? 'require-signed' : 'transitional',
 				is_array( $cv_bot_ip ) ? count( $cv_bot_ip ) : 0,
 				$is_local ? ', LOCAL_ENV' : ''
 			) );
 		}
 
-		return $test_type && $ip_verified;
+		return $result;
+	}
+
+	/**
+	 * Determines whether the current request carries a valid CheckView SaaS
+	 * signature.
+	 *
+	 * The CheckView test runner attaches a short-lived RS256 JWT as the
+	 * `X-CheckView-Signature` header on every same-domain request. The value
+	 * cannot be forged by a client and passes through proxies/CDNs intact, so it
+	 * authenticates the bot even where forwarding headers are spoofable. Reuses
+	 * the exact validation the REST API already trusts (RS256 signature, site
+	 * binding, and expiry) via checkview_validate_jwt_token().
+	 *
+	 * @since 2.1.1
+	 *
+	 * @return bool True when a valid signature is present, false otherwise.
+	 */
+	private static function is_request_signed(): bool {
+		if ( empty( $_SERVER['HTTP_X_CHECKVIEW_SIGNATURE'] ) ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'checkview_validate_jwt_token' ) ) {
+			return false;
+		}
+
+		$header = trim( wp_unslash( $_SERVER['HTTP_X_CHECKVIEW_SIGNATURE'] ) );
+		if ( '' === $header ) {
+			return false;
+		}
+
+		// checkview_validate_jwt_token() expects a "Bearer <jwt>" string.
+		if ( 0 !== strpos( $header, 'Bearer ' ) ) {
+			$header = 'Bearer ' . $header;
+		}
+
+		$nonce = checkview_validate_jwt_token( $header );
+
+		// A non-empty string (the token's nonce) means the signature validated;
+		// a WP_Error, false, or empty string means it did not.
+		return is_string( $nonce ) && '' !== $nonce;
 	}
 
 	/**


### PR DESCRIPTION
> **DRAFT / do not merge yet.** Part 2 of a coordinated two-PR fix. Depends on the SaaS half (CheckView/checkview#1116) shipping first. Inert until that's live AND an operator flips the enforcement switch. Owner: @grayson to review + verify against a real WooCommerce run + a Cloudflare-fronted site before merge. Tracking: https://app.clickup.com/t/868jvxxje

## Why

`CheckView::is_bot()` authenticates the testing bot via a **client-spoofable IP allowlist** — the root of the Patchstack Broken Access Control report (CVSS 7.5). PR #218 removed the hardcoded backdoor IPs (killing the published PoC), but an attacker who learns a real bot IP can still spoof `X-Forwarded-For` on sites that don't sanitize forwarding headers.

This lets `is_bot()` trust an **unforgeable** signal instead: the SaaS-signed `X-CheckView-Signature` header, verified with the **same RS256 key + site-binding + expiry the REST API already trusts** (`checkview_validate_jwt_token`). No new secret, no new key distribution.

## What

- **`is_request_signed()`** (new, private) — validates the header. Early-returns if the header is absent, so it costs nothing for ordinary visitor traffic; JWT work only happens on actual bot requests.
- **`is_bot()`** — new `checkview_require_signed_request` filter (default **false**):
  - **Transitional (default):** pass if `signature OR IP allowlist`. Purely additive — **no behavior change** for current tests, since the SaaS isn't sending the header until #1116 deploys.
  - **Enforced (filter true):** a valid signature is **required**; the spoofable IP is demoted to insufficient-on-its-own. This is the moment the hole actually closes.
- Bot-check log line now records `sig_ok` + `mode` for the rollout.

## Why it's safe to merge ahead of the cutover

With the filter at its default `false` and the SaaS not yet signing, `is_request_signed()` returns false and `verified` collapses to exactly the current IP check. Nothing changes for any running test on the QA/InstaWP fleet. No version bump (quality-branch policy).

## Rollout (owner)

1. Ship + deploy SaaS PR #1116 (signing). Confirm `sig_ok=[yes]` appearing in `ip-logs` on real runs.
2. Merge this PR (still default-off/transitional).
3. Flip `checkview_require_signed_request` → true to enforce. Note: **no central remote toggle exists** — see tracking ticket for how the flip must actually be driven (it can't be a per-site option push). Roll out QA-first.

## Verification checklist (owner)

- [ ] With #1116 live, real `full_checkout` + `form` tests log `sig_ok=[yes]` and still PASS.
- [ ] Cloudflare-fronted site: signature arrives intact and validates.
- [ ] With the filter forced on, a spoofed-IP request **without** a signature FAILS the bot check; a legit signed run PASSES.

## Not in this PR (tracked)

- [ ] `test-flow-steps-generator` must also send the signature before enforcing, or initial generation runs get rejected.
- [ ] `WP_ENVIRONMENT_TYPE === 'local'` unconditional bypass (line ~176) — close/gate separately.
- [ ] Audit/remove the per-IP `update_option($visitor_ip, 'checkview-saas')` write (`TODO: What is this for?`).
- [ ] Replay hardening (single-use nonce consumption) — decide during enforcement design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)