### PR TITLE
fix(elementor): stop submission cleanup from deleting customer submissions

### DIFF
--- a/includes/formhelpers/class-checkview-elementor-helper.php
+++ b/includes/formhelpers/class-checkview-elementor-helper.php
@@ -373,9 +373,13 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 				}
 			}
 
-			// Remove the just-saved submission from Elementor's tables.
+			// Remove the just-saved submission from Elementor's tables. All three
+			// are keyed to the submission: `e_submissions_actions_log` was
+			// previously left behind, orphaning one row per non-save action
+			// (e.g. the email action) on every test run.
 			$submissions_table = $wpdb->prefix . 'e_submissions';
 			$values_table      = $wpdb->prefix . 'e_submissions_values';
+			$actions_log_table = $wpdb->prefix . 'e_submissions_actions_log';
 
 			// Elementor only writes to `e_submissions` when the form's
 			// `save-to-database` action is enabled. When it is not, this test
@@ -426,16 +430,22 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 					if ( empty( $ids ) ) {
 						Checkview_Admin_Logs::add(
 							'ip-logs',
-							'Skipping Elementor submission cleanup for form [' . $form_id . ']: '
+							'Skipping Elementor submission cleanup for form [' . $form_id . '] (element_id [' . $element_id . ']): '
 							. count( is_array( $candidates ) ? $candidates : array() )
 							. ' row(s) newer than watermark [' . $watermark . '] and none could be attributed to this test.'
 						);
 					}
 
+					$has_actions_log = ! empty( $ids )
+						&& $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $actions_log_table ) ) === $actions_log_table;
+
 					foreach ( $ids as $submission_id ) {
+						if ( $has_actions_log ) {
+							$wpdb->delete( $actions_log_table, array( 'submission_id' => $submission_id ), array( '%d' ) );
+						}
 						$wpdb->delete( $values_table, array( 'submission_id' => $submission_id ), array( '%d' ) );
 						$wpdb->delete( $submissions_table, array( 'id' => $submission_id ), array( '%d' ) );
-						Checkview_Admin_Logs::add( 'ip-logs', 'Deleted Elementor submission [' . $submission_id . '] from ' . $submissions_table . '.' );
+						Checkview_Admin_Logs::add( 'ip-logs', 'Deleted Elementor submission [' . $submission_id . '] (element_id [' . $element_id . ']) from ' . $submissions_table . '.' );
 					}
 				}
 			}

--- a/includes/formhelpers/class-checkview-elementor-helper.php
+++ b/includes/formhelpers/class-checkview-elementor-helper.php
@@ -160,7 +160,14 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 		public function checkview_capture_submission_watermark( $record, $handler ) {
 			global $wpdb;
 
-			if ( ! $record || ! get_checkview_test_id() ) {
+			// Deliberately NOT gated on get_checkview_test_id(): cleanup in
+			// checkview_clone_elementor_entry() runs whenever this helper is
+			// loaded and tolerates an empty test id, so gating capture on it
+			// would let the two diverge — cleanup would find no watermark and
+			// silently skip. The helper is only ever loaded inside a verified
+			// test request, so capturing unconditionally costs one indexed
+			// MAX() per submission.
+			if ( ! $record ) {
 				return $record;
 			}
 
@@ -192,6 +199,22 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 		 * from CheckView's bot IP. When the form has IP collection disabled
 		 * (`user_ip` is stored empty), fall back to the unambiguous case of a
 		 * single new row.
+		 *
+		 * The IP match is best-effort and often will not fire behind a proxy.
+		 * Elementor resolves the stored value with `Utils::get_client_ip()`,
+		 * whose header list omits `HTTP_CF_CONNECTING_IP` and which requires the
+		 * whole header to pass `filter_var()` — so a comma-list
+		 * `X-Forwarded-For` falls through to `REMOTE_ADDR`. Behind Cloudflare
+		 * that is the edge IP, while `checkview_get_visitor_ip()` resolves the
+		 * real bot IP from `CF-Connecting-IP`. The two then disagree and no
+		 * candidate matches, which degrades safely to the single-row rule (and
+		 * to deleting nothing when a race actually occurs).
+		 *
+		 * Widening the comparison to "whatever Elementor would have stored for
+		 * this request" would be actively unsafe: behind a proxy a concurrent
+		 * customer submission carries that same edge IP, so it would start
+		 * matching real submissions. Only an exact bot-IP match is trustworthy,
+		 * because nothing else can legitimately carry it.
 		 *
 		 * Returns an empty array when attribution is ambiguous — the caller
 		 * must then delete nothing. Leaving a test row behind is recoverable;

--- a/includes/formhelpers/class-checkview-elementor-helper.php
+++ b/includes/formhelpers/class-checkview-elementor-helper.php
@@ -35,12 +35,17 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 		public $loader;
 
 		/**
-		 * Highest `e_submissions.id` for this form immediately before Elementor
-		 * ran its submit actions, keyed by form (element) id.
+		 * Highest `e_submissions.id` seen immediately before Elementor ran its
+		 * submit actions, keyed by the submission element id.
 		 *
-		 * Used to bound submission cleanup to rows this test created. `null`
-		 * for a form means no watermark was captured, in which case cleanup
-		 * refuses to delete anything rather than guessing.
+		 * The key is the value from `checkview_get_submission_element_id()`,
+		 * i.e. what Elementor writes to `e_submissions.element_id` — not
+		 * `$record->get_form_settings( 'id' )`, which differs for forms inside
+		 * a global template.
+		 *
+		 * Used to bound submission cleanup to rows this test created. A missing
+		 * key means no watermark was captured for that element, in which case
+		 * cleanup refuses to delete anything rather than guessing.
 		 *
 		 * @var array<string,int>
 		 */

--- a/includes/formhelpers/class-checkview-elementor-helper.php
+++ b/includes/formhelpers/class-checkview-elementor-helper.php
@@ -33,6 +33,19 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 		 * @var Checkview_Loader $loader Maintains and registers all hooks for the plugin.
 		 */
 		public $loader;
+
+		/**
+		 * Highest `e_submissions.id` for this form immediately before Elementor
+		 * ran its submit actions, keyed by form (element) id.
+		 *
+		 * Used to bound submission cleanup to rows this test created. `null`
+		 * for a form means no watermark was captured, in which case cleanup
+		 * refuses to delete anything rather than guessing.
+		 *
+		 * @var array<string,int>
+		 */
+		private $submission_watermarks = array();
+
 		/**
 		 * Constructor.
 		 *
@@ -40,6 +53,22 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 		 */
 		public function __construct() {
 			$this->loader = new Checkview_Loader();
+
+			// Record the newest pre-existing submission id BEFORE Elementor runs
+			// its submit actions, so cleanup can tell our row from the customer's.
+			// `elementor_pro/forms/record/actions_before` (Elementor Pro 3.3.0+,
+			// Ajax_Handler) is the last seam before the action loop that contains
+			// `save-to-database`. A `new_record` callback cannot serve here at any
+			// priority — that action fires *after* the whole action loop.
+			add_filter(
+				'elementor_pro/forms/record/actions_before',
+				array(
+					$this,
+					'checkview_capture_submission_watermark',
+				),
+				1,
+				2
+			);
 
 			add_action(
 				'elementor_pro/forms/new_record',
@@ -113,6 +142,98 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 		}
 
 		/**
+		 * Records the highest existing `e_submissions.id` for this form before
+		 * Elementor runs its submit actions.
+		 *
+		 * Runs on `elementor_pro/forms/record/actions_before`, the last hook
+		 * that fires before the action loop containing `save-to-database`.
+		 * Everything created at or below this id predates the test submission
+		 * and must never be deleted by cleanup.
+		 *
+		 * Registered as a filter and returns `$record` untouched — the hook is
+		 * a filter on the record, not an action.
+		 *
+		 * @param \ElementorPro\Modules\Forms\Classes\Form_Record  $record  Form record.
+		 * @param \ElementorPro\Modules\Forms\Classes\Ajax_Handler $handler Ajax handler.
+		 * @return \ElementorPro\Modules\Forms\Classes\Form_Record Unmodified record.
+		 */
+		public function checkview_capture_submission_watermark( $record, $handler ) {
+			global $wpdb;
+
+			if ( ! $record || ! get_checkview_test_id() ) {
+				return $record;
+			}
+
+			$form_id = $record->get_form_settings( 'id' );
+			if ( empty( $form_id ) ) {
+				return $record;
+			}
+
+			$submissions_table = $wpdb->prefix . 'e_submissions';
+			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $submissions_table ) ) !== $submissions_table ) {
+				return $record;
+			}
+
+			$this->submission_watermarks[ (string) $form_id ] = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT COALESCE(MAX(id), 0) FROM ' . $submissions_table . ' WHERE element_id = %s',
+					$form_id
+				)
+			);
+
+			return $record;
+		}
+
+		/**
+		 * Decides which post-watermark submissions belong to this test run.
+		 *
+		 * Attribution is by visitor IP: Elementor stores the submitter's IP in
+		 * `e_submissions.user_ip`, and a real customer will not be submitting
+		 * from CheckView's bot IP. When the form has IP collection disabled
+		 * (`user_ip` is stored empty), fall back to the unambiguous case of a
+		 * single new row.
+		 *
+		 * Returns an empty array when attribution is ambiguous — the caller
+		 * must then delete nothing. Leaving a test row behind is recoverable;
+		 * deleting a customer's submission is not.
+		 *
+		 * Pure function of its inputs so it can be tested without a database.
+		 *
+		 * @param array  $candidates Rows with `id` and `user_ip`, newer than the watermark.
+		 * @param string $visitor_ip Current visitor IP (CheckView's bot IP during a test).
+		 * @return int[] Submission ids safe to delete; empty when undecidable.
+		 */
+		public function checkview_select_own_submissions( array $candidates, $visitor_ip ) {
+			$visitor_ip = (string) $visitor_ip;
+			$matched    = array();
+
+			if ( '' !== $visitor_ip ) {
+				foreach ( $candidates as $row ) {
+					$row_ip = is_object( $row ) ? ( $row->user_ip ?? '' ) : ( $row['user_ip'] ?? '' );
+					if ( (string) $row_ip === $visitor_ip ) {
+						$row_id    = is_object( $row ) ? ( $row->id ?? 0 ) : ( $row['id'] ?? 0 );
+						$matched[] = (int) $row_id;
+					}
+				}
+			}
+
+			if ( ! empty( $matched ) ) {
+				return $matched;
+			}
+
+			// No IP match. A single new row is unambiguously the one this test
+			// just created (Elementor stores an empty user_ip when the form
+			// omits `remote_ip` from its submissions metadata).
+			if ( 1 === count( $candidates ) ) {
+				$only    = reset( $candidates );
+				$only_id = is_object( $only ) ? ( $only->id ?? 0 ) : ( $only['id'] ?? 0 );
+				return array( (int) $only_id );
+			}
+
+			return array();
+		}
+
+		/**
 		 * Clones the Elementor submission into CheckView tables, deletes the
 		 * original Elementor submission, and finishes the testing session.
 		 *
@@ -134,11 +255,16 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 				$checkview_test_id = $form_id . gmdate( 'Ymd' );
 			}
 
-			// `cv_entry.form_id` is numeric (mediumint). Elementor's form id can
-			// be a non-numeric string, which the column would silently store as
-			// 0. Surface it so the SaaS-side form-id strategy can be finalized.
+			// Elementor form ids are 7-character widget element ids, so they are
+			// non-numeric roughly 96% of the time, and `cv_entry.form_id` is a
+			// mediumint that silently coerces them to 0. This is inert today:
+			// results are retrieved by `uid`, never by `form_id` (see
+			// Checkview_Api::checkview_get_test_results). Logged as a note
+			// rather than a WARNING because it is the normal case, not a fault.
+			// If `form_id` is ever made meaningful for Elementor, the column has
+			// to become a varchar first.
 			if ( ! is_numeric( $form_id ) ) {
-				Checkview_Admin_Logs::add( 'ip-logs', 'WARNING: Elementor form id [' . $form_id . '] is non-numeric; cv_entry.form_id will store 0.' );
+				Checkview_Admin_Logs::add( 'ip-logs', 'Note: Elementor form id [' . $form_id . '] is non-numeric; cv_entry.form_id stores 0 (unused for Elementor lookups).' );
 			}
 
 			Checkview_Admin_Logs::add( 'ip-logs', 'Cloning Elementor submission for form [' . $form_id . ']...' );
@@ -196,21 +322,60 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 			$submissions_table = $wpdb->prefix . 'e_submissions';
 			$values_table      = $wpdb->prefix . 'e_submissions_values';
 
-			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $submissions_table ) ) === $submissions_table ) {
-				// TODO: This removes ANY submission from the form - high-velocity forms could have a submission between CheckView submission and here
-				$submission_id = $wpdb->get_var(
-					$wpdb->prepare(
-						'SELECT id FROM ' . $submissions_table . ' WHERE element_id = %s ORDER BY id DESC LIMIT 1',
-						$form_id
-					)
-				);
+			// Elementor only writes to `e_submissions` when the form's
+			// `save-to-database` action is enabled. When it is not, this test
+			// created no row at all, so anything newer than the watermark
+			// belongs to a real visitor and must be left alone. Forms that once
+			// saved submissions and no longer do still have history here, which
+			// is what made the previous unscoped delete destructive.
+			$saves_submissions = in_array(
+				'save-to-database',
+				(array) $record->get_form_settings( 'submit_actions' ),
+				true
+			);
 
-				if ( $submission_id ) {
-					$wpdb->delete( $values_table, array( 'submission_id' => $submission_id ), array( '%d' ) );
-					$wpdb->delete( $submissions_table, array( 'id' => $submission_id ), array( '%d' ) );
-					Checkview_Admin_Logs::add( 'ip-logs', 'Deleted Elementor submission [' . $submission_id . '] from ' . $submissions_table . '.' );
+			if ( ! $saves_submissions ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Skipping Elementor submission cleanup for form [' . $form_id . ']: form does not have the save-to-database action, so this test created no submission row.' );
+			} elseif ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $submissions_table ) ) === $submissions_table ) {
+				$watermark = isset( $this->submission_watermarks[ (string) $form_id ] )
+					? $this->submission_watermarks[ (string) $form_id ]
+					: null;
+
+				if ( null === $watermark ) {
+					// No watermark means we cannot distinguish our submission from
+					// the customer's. Deleting the newest row here is what caused
+					// real submissions to be destroyed; leaving the test row behind
+					// is the strictly safer failure.
+					Checkview_Admin_Logs::add( 'ip-logs', 'Skipping Elementor submission cleanup for form [' . $form_id . ']: no pre-submission watermark was captured, so the test row cannot be identified safely.' );
 				} else {
-					Checkview_Admin_Logs::add( 'ip-logs', 'Could delete Elementor submission with submission ID: ' . wp_json_encode( $submission_id ) );
+					// Only rows created after the watermark can belong to this test.
+					$candidates = $wpdb->get_results(
+						$wpdb->prepare(
+							'SELECT id, user_ip FROM ' . $submissions_table . ' WHERE element_id = %s AND id > %d ORDER BY id ASC',
+							$form_id,
+							$watermark
+						)
+					);
+
+					$ids = $this->checkview_select_own_submissions(
+						is_array( $candidates ) ? $candidates : array(),
+						checkview_get_visitor_ip()
+					);
+
+					if ( empty( $ids ) ) {
+						Checkview_Admin_Logs::add(
+							'ip-logs',
+							'Skipping Elementor submission cleanup for form [' . $form_id . ']: '
+							. count( is_array( $candidates ) ? $candidates : array() )
+							. ' row(s) newer than watermark [' . $watermark . '] and none could be attributed to this test.'
+						);
+					}
+
+					foreach ( $ids as $submission_id ) {
+						$wpdb->delete( $values_table, array( 'submission_id' => $submission_id ), array( '%d' ) );
+						$wpdb->delete( $submissions_table, array( 'id' => $submission_id ), array( '%d' ) );
+						Checkview_Admin_Logs::add( 'ip-logs', 'Deleted Elementor submission [' . $submission_id . '] from ' . $submissions_table . '.' );
+					}
 				}
 			}
 

--- a/includes/formhelpers/class-checkview-elementor-helper.php
+++ b/includes/formhelpers/class-checkview-elementor-helper.php
@@ -171,8 +171,8 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 				return $record;
 			}
 
-			$form_id = $record->get_form_settings( 'id' );
-			if ( empty( $form_id ) ) {
+			$element_id = $this->checkview_get_submission_element_id( $handler );
+			if ( null === $element_id ) {
 				return $record;
 			}
 
@@ -181,14 +181,46 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 				return $record;
 			}
 
-			$this->submission_watermarks[ (string) $form_id ] = (int) $wpdb->get_var(
+			$this->submission_watermarks[ $element_id ] = (int) $wpdb->get_var(
 				$wpdb->prepare(
 					'SELECT COALESCE(MAX(id), 0) FROM ' . $submissions_table . ' WHERE element_id = %s',
-					$form_id
+					$element_id
 				)
 			);
 
 			return $record;
+		}
+
+		/**
+		 * Resolves the value Elementor stores in `e_submissions.element_id`.
+		 *
+		 * Must come from `Ajax_Handler::get_current_form()['id']`, because that
+		 * is exactly what the `save-to-database` action writes to the column.
+		 * `$record->get_form_settings( 'id' )` is NOT equivalent: Ajax_Handler
+		 * assigns `$form['settings']['id'] = $form_id` from the posted id, but
+		 * when the form lives inside a global template it first reassigns
+		 * `$form = $template->get_elements_data()[0]`, leaving `$form['id']`
+		 * pointing at the template's element while `settings['id']` keeps the
+		 * posted one. Querying by the settings value silently matches nothing
+		 * for those forms.
+		 *
+		 * `current_form` is populated before `record/actions_before` fires, so
+		 * this resolves identically in both the capture and cleanup callbacks.
+		 *
+		 * @param \ElementorPro\Modules\Forms\Classes\Ajax_Handler $handler Ajax handler.
+		 * @return string|null Element id, or null when it cannot be resolved.
+		 */
+		private function checkview_get_submission_element_id( $handler ) {
+			if ( ! $handler || ! method_exists( $handler, 'get_current_form' ) ) {
+				return null;
+			}
+
+			$form = $handler->get_current_form();
+			if ( ! is_array( $form ) || empty( $form['id'] ) ) {
+				return null;
+			}
+
+			return (string) $form['id'];
 		}
 
 		/**
@@ -357,11 +389,17 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 				true
 			);
 
+			// Query by the element id Elementor actually stored, not by the form
+			// settings id — see checkview_get_submission_element_id().
+			$element_id = $this->checkview_get_submission_element_id( $handler );
+
 			if ( ! $saves_submissions ) {
 				Checkview_Admin_Logs::add( 'ip-logs', 'Skipping Elementor submission cleanup for form [' . $form_id . ']: form does not have the save-to-database action, so this test created no submission row.' );
+			} elseif ( null === $element_id ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Skipping Elementor submission cleanup for form [' . $form_id . ']: could not resolve the submission element id from the ajax handler.' );
 			} elseif ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $submissions_table ) ) === $submissions_table ) {
-				$watermark = isset( $this->submission_watermarks[ (string) $form_id ] )
-					? $this->submission_watermarks[ (string) $form_id ]
+				$watermark = isset( $this->submission_watermarks[ $element_id ] )
+					? $this->submission_watermarks[ $element_id ]
 					: null;
 
 				if ( null === $watermark ) {
@@ -375,7 +413,7 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 					$candidates = $wpdb->get_results(
 						$wpdb->prepare(
 							'SELECT id, user_ip FROM ' . $submissions_table . ' WHERE element_id = %s AND id > %d ORDER BY id ASC',
-							$form_id,
+							$element_id,
 							$watermark
 						)
 					);


### PR DESCRIPTION
## Summary

Elementor submission cleanup picked its delete target with:

```sql
SELECT id FROM e_submissions WHERE element_id = %s ORDER BY id DESC LIMIT 1
```

The newest submission for the form, with nothing tying it to the test run. The pre-existing `// TODO:` on that line called out the race; the deterministic case below was not known.

## Two ways this destroyed customer data

**Race.** `elementor_pro/forms/new_record` fires *after* the entire submit-action loop — in Elementor Pro's `Ajax_Handler`, actions run at lines 166-200 and the hook fires at line 224. CheckView's callback is priority 999 on that hook. So the window between Elementor's insert and this delete spans the remainder of the action chain, including the SMTP round trip for the notification email. A customer submission landing in that window was deleted instead of the test's.

**Deterministic — no concurrency required.** The cleanup block ran unconditionally whenever the `e_submissions` table existed, including when the test created no row at all (form has no `save-to-database` action). `ORDER BY id DESC LIMIT 1` then returned the newest *pre-existing customer* submission and deleted it. A form that once saved submissions and no longer does loses one historical row per test run, walking backwards through history.

## The fix

Three independent guards:

0. **Correct key.** All `e_submissions` queries resolve the element id from `Ajax_Handler::get_current_form()['id']` — the exact value `save-to-database` writes to the column. `$record->get_form_settings('id')` is *not* equivalent: for forms inside a global template, Ajax_Handler reassigns `$form = $template->get_elements_data()[0]` before setting `$form['settings']['id'] = $form_id`, so the two diverge. The old query used the settings value and therefore matched nothing for those forms. **Behaviour change:** test submissions on global-template forms are now cleaned up, where previously they were left behind.

1. **Watermark.** Capture `MAX(id)` for the form on `elementor_pro/forms/record/actions_before` — the last seam before the action loop containing `save-to-database`. Only rows above it can belong to this test. Note a `new_record` callback *cannot* serve this purpose at any priority, since that action fires after the loop.
2. **IP attribution (best-effort).** Elementor stores the submitter's IP in `e_submissions.user_ip` (`varchar(46)`, indexed). Real visitors don't submit from CheckView's bot IP. Falls back to the single-new-row case for forms that omit `remote_ip` from submissions metadata, where Elementor stores `user_ip` empty.

   **This guard often will not fire behind a proxy.** Elementor resolves the stored value with `Utils::get_client_ip()`, whose header list omits `HTTP_CF_CONNECTING_IP` and which requires the whole header to pass `filter_var()` — so a comma-list `X-Forwarded-For` falls through to `REMOTE_ADDR`. Behind Cloudflare that is the edge IP, while `checkview_get_visitor_ip()` resolves the real bot IP from `CF-Connecting-IP`. The two disagree, nothing matches, and attribution degrades to the single-row rule — and to deleting nothing when a race actually occurs. Safe, but it means guards 1 and 3 carry most of the weight on proxied sites.

   Widening the comparison to "whatever Elementor would have stored for this request" would be *actively unsafe*: behind a proxy a concurrent customer submission carries that same edge IP, so it would begin matching real submissions. Only an exact bot-IP match is trustworthy.
3. **Action check.** Skip cleanup entirely when the form has no `save-to-database` action — no row of ours exists to remove.

When attribution is ambiguous, **delete nothing and log**. Leaving a test row behind is recoverable; deleting a customer submission is not.

## Verification

Attribution is a pure method (`checkview_select_own_submissions`), covered by 10 executed assertions — no DB required:

- race: only the bot-IP row deleted, order-independent
- deterministic case: zero candidates → nothing deleted
- IP collection disabled: single row deleted; ambiguous pair → nothing deleted
- unresolvable visitor IP → nothing deleted
- customer-row-only → never deleted
- bot retry (two bot rows) → both deleted

**Not executed:** the DB-facing paths (watermark capture, the scoped `SELECT`, the `submit_actions` guard). The repo's PHPUnit suite doesn't run from a normal checkout — `tests/bootstrap.php` resolves WordPress via `dirname(__DIR__, 4)`, assuming the plugin sits under `wp-content/plugins/` — and the `.github/workflows` jobs are wordpress.org SVN update checkers, not test runners. A live Elementor test run should confirm the test submission is still removed.

**Residual risk, stated plainly:** the single-row fallback deletes the one post-watermark row when no bot-IP match is available. If our own insert failed while exactly one concurrent customer submission landed in the window, that row would be deleted. It requires `save-to-database` enabled (so our row *should* exist) plus our insert failing plus a concurrent submission. Far narrower than the previous "always the newest row," but not zero — and on proxied sites the IP guard will not be there to catch it.

**Cleanup now fails toward leaving rows behind.** On a real race with no usable IP match, nothing is deleted and the test submission stays in the customer's table. That is the intended trade: a stray test row is recoverable, a deleted customer submission is not. Expect occasional leftover test submissions on busy proxied sites.

## Also in this PR

- **Orphaned actions-log rows.** Elementor keys three tables to a submission — `e_submissions`, `e_submissions_values` and `e_submissions_actions_log`. Cleanup only ever removed the first two, so every test run orphaned one actions-log row per non-save action (usually the email action), accumulating indefinitely. Now deleted alongside the others, behind a table check hoisted out of the loop.

- The failure log read `"Could delete…"` (missing "not") and json-encoded a value that is always falsy in that branch, so it logged `null` every time.
- The non-numeric `form_id` WARNING fires on ~96% of Elementor tests — element ids are 7-char hex, so all-digits probability is (10/16)⁷ ≈ 3.7% — while being inert, since results are fetched by `uid` and `form_id` is never read back for Elementor. Downgraded to a note, with a comment recording that the column must become a varchar if `form_id` is ever made meaningful.

## Base

Based on `development`. Independent of the `allow_original_recipients` work in #197 — no overlapping hunks.

