### PR TITLE
fix(elementor): unhook Simple CF Turnstile's widget render during tests

### DIFF
--- a/includes/formhelpers/class-checkview-elementor-helper.php
+++ b/includes/formhelpers/class-checkview-elementor-helper.php
@@ -133,6 +133,11 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 				'__return_true',
 				999
 			);
+
+			// The filter above is necessary but not sufficient for Elementor.
+			// See checkview_unhook_turnstile_elementor_widget() for why.
+			$this->checkview_unhook_turnstile_elementor_widget();
+
 			add_filter(
 				'akismet_get_api_key',
 				'__return_null',
@@ -291,6 +296,57 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 			}
 
 			return array();
+		}
+
+		/**
+		 * Stops Simple CAPTCHA with Cloudflare Turnstile from rendering its
+		 * widget on Elementor forms during a test.
+		 *
+		 * That plugin consults `cfturnstile_whitelisted()` only in its
+		 * verification callback (`elementor_pro/forms/validation`). Its Elementor
+		 * widget is rendered by a *separate* `wp_enqueue_scripts` callback which
+		 * never checks the whitelist, and which loads
+		 * `js/integrations/elementor-forms.js` to inject the field client-side.
+		 *
+		 * So during a test the widget still renders, `cf-turnstile-response`
+		 * stays empty, and the submission is blocked in the browser — meaning
+		 * the validation hook never fires and the `cfturnstile_whitelisted`
+		 * filter is never reached. Whitelisting alone guards a door the request
+		 * never gets to; the widget has to be stopped from rendering.
+		 *
+		 * Elementor is the only integration in that plugin with this gap. Every
+		 * other one (CF7, WPForms, Gravity, Fluent, Formidable, Forminator,
+		 * WooCommerce) renders through the shared `cfturnstile_field_show()`,
+		 * which does check `cfturnstile_whitelisted()` before emitting anything.
+		 *
+		 * Timing: that plugin registers the enqueue when its integration file is
+		 * included at plugin-load, while this helper is constructed from
+		 * `checkview_init_current_test()` on `init` priority 10 — earlier than
+		 * `wp_enqueue_scripts`, so the callback is present and removable here.
+		 *
+		 * The priority is looked up rather than hardcoded, so an upstream change
+		 * to it degrades into a logged no-op instead of a silent one.
+		 *
+		 * @return void
+		 */
+		private function checkview_unhook_turnstile_elementor_widget() {
+			// Absent unless Simple CF Turnstile is active with its Elementor
+			// integration loaded. Nothing to do, and nothing worth logging.
+			if ( ! function_exists( 'cfturnstile_elementor_enqueue_scripts' ) ) {
+				return;
+			}
+
+			// Strict comparison: has_action() returns the priority, which may
+			// legitimately be 0.
+			$priority = has_action( 'wp_enqueue_scripts', 'cfturnstile_elementor_enqueue_scripts' );
+
+			if ( false === $priority ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Simple CF Turnstile Elementor enqueue exists but is not hooked to wp_enqueue_scripts; the Turnstile widget may still render and block submission (upstream hook may have changed).' );
+				return;
+			}
+
+			remove_action( 'wp_enqueue_scripts', 'cfturnstile_elementor_enqueue_scripts', $priority );
+			Checkview_Admin_Logs::add( 'ip-logs', 'Unhooked Simple CF Turnstile Elementor widget enqueue (priority ' . $priority . ') so the Turnstile field does not render during the test.' );
 		}
 
 		/**


### PR DESCRIPTION
## Symptom

Elementor form tests fail on sites running **Simple CAPTCHA with Cloudflare Turnstile**. The submission never reaches the server — the helper logs a page load and then nothing:

```
16:22:59  Loading Elementor Forms helper.      ← page load
          (no second load, no clone, silence)
```

A working site shows two helper loads and a clone (page load, then the submission POST).

## Root cause

The `cfturnstile_whitelisted` filter the helper already sets is **correctly named and correctly hooked** — the plugin genuinely calls `apply_filters('cfturnstile_whitelisted', false)`. It is simply downstream of where the block happens.

Simple CF Turnstile's Elementor integration registers exactly two hooks:

```php
add_action('wp_enqueue_scripts', 'cfturnstile_elementor_enqueue_scripts', 99);      // renders the widget
add_action('elementor_pro/forms/validation', 'cfturnstile_elementor_check', 10, 2); // verifies it

function cfturnstile_elementor_check($record, $ajax_handler){
    if(!cfturnstile_whitelisted()) {   // ← the ONLY whitelist check
```

The render path never consults the whitelist. During a test the widget still gets injected (by `js/integrations/elementor-forms.js`, loaded from that enqueue), `cf-turnstile-response` stays empty, and the browser blocks the submit. The validation hook therefore never fires and our filter is never reached — **it guards a door the request never gets to**.

Confirmed live in the DOM on the failing site:

```
.elementor-turnstile-field.cf-turnstile   ← widget present
input[name="cf-turnstile-response"]       ← present, value: (EMPTY)
```

## Why only Elementor

Verified against 1.42.1: **Elementor is the only integration with this gap.** Every other one — CF7, WPForms, Gravity Forms, Fluent Forms, Formidable, Forminator, WooCommerce — renders through the shared `cfturnstile_field_show()`, which checks the whitelist before emitting anything:

```php
// inc/turnstile.php:15-22
function cfturnstile_field_show(...) {
    $hide = apply_filters('cfturnstile_widget_disable', false);
    if($hide) { return; }
    if(!cfturnstile_whitelisted()) {   // ← gated here
```

Elementor bypasses that helper entirely and injects client-side instead. **No other form helper needs this change.**

## The fix

Remove the render-side callback in the Elementor helper's constructor, keeping the existing filter as the server-side half. With the widget gone, the validation callback still runs on submit and short-circuits on the whitelist.

**Timing holds.** Simple CF Turnstile registers the enqueue when its integration file is included at plugin-load — a top-level conditional in the main plugin file (`if (...)` at column 0, line 128), not inside a hook callback. This helper is constructed from `checkview_init_current_test()` on `init` priority 10, which is after plugin-load and before `wp_enqueue_scripts`. The callback is present and removable at that point.

**Not fragile.** The priority is resolved with `has_action()` rather than hardcoded, so an upstream priority change still works. If the callback moves to a different hook entirely, it degrades to a *logged* no-op rather than a silent one. The `false ===` comparison keeps a legitimate priority `0` from being misread as "not registered". When the plugin isn't installed, it returns silently with no log noise.

## Verification

The removal logic was executed against an emulation of WordPress's `has_action`/`remove_action` semantics — **11 assertions, all passing**:

- plugin absent → silent no-op, nothing logged
- registered at 99 (upstream default) → removed
- registered at 5 → still removed (priority not hardcoded)
- registered at 0 → removed, not misread as absent
- moved to a different hook → reports not-hooked *and* logs a diagnostic
- a sibling callback at the same priority is left untouched

**Not verified:** a live test run against the failing site. This change is unhooking a render callback, so the expected outcome is that the widget stops appearing and the form submits — worth confirming on `elementorformssimplecf.instawp.xyz` before merge.

One thing inherited from the original diagnosis and worth stating plainly: the *precise* client-side step that blocks the submit (most likely Elementor's own required-field validation on the empty token) was inferred, not observed. It doesn't affect the fix — with no widget rendered there is nothing to block or verify — but it does mean the failure mechanism is established by elimination rather than directly.