### PR TITLE
chore: ignore the wordpress/ dev artifact in git and dist builds

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,6 +4,7 @@
 /.github
 /.cache
 /node_modules
+/wordpress
 /tests
 /grunt
 /vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 .vscode
 wp-content
+# WordPress core, installed by the roots/wordpress dev dependency.
+/wordpress
 public_html/*
 site/*
 web/*


### PR DESCRIPTION
## What

`composer install` pulls the `roots/wordpress` dev dependency, which extracts a full WordPress core tree (**~52MB**) to `/wordpress` at the repo root.

That path is listed in **neither** `.gitignore` nor `.distignore`.

## Why it matters

- It shows as untracked noise in every `git status`, inviting an accidental `git add -A`
- More importantly, nothing stops it being swept into a WordPress.org distribution build if it exists when the build runs — shipping WordPress core *inside* the plugin zip

`.distignore` already lists `/.wordpress-org`, but that's the WP.org assets directory — a different path that does not cover this. Easy to misread as coverage, which is what I did on first inspection.

## Change

Two lines: `/wordpress` added to `.gitignore` and `.distignore`. No runtime code touched.

## Verification

- `git check-ignore -v wordpress` → matched by `.gitignore:5`
- `git status` no longer reports the directory
- `grep -n "^/wordpress$" .distignore` → present

Surfaced while running Composer for #226.