### PR TITLE
fix(formidable): discover forms placed with the block editor or quoted shortcodes

### DIFF
--- a/includes/API/class-checkview-api.php
+++ b/includes/API/class-checkview-api.php
@@ -1444,19 +1444,53 @@ class CheckView_Api {
 						'Name' => $row->name,
 					);
 
+					// Mirrors Formidable's own reference detection —
+					// FrmFormsListHelper::get_base_search_strings_for_form()
+					// (verified against Formidable 6.33.1). A form can be placed
+					// five ways; CheckView previously matched only the first:
+					//
+					//   1. [formidable id=N]
+					//   2. [formidable id=N title=false]   (extra attributes)
+					//   3. [formidable id="N"]             (what Formidable's UI emits)
+					//   4. [formidable id='N']
+					//   5. <!-- wp:formidable/simple-form {"formId":"N"} -->
+					//
+					// Patterns 2-5 never matched, so a form placed with the block
+					// editor — or with the shortcode copied from Formidable's own
+					// UI — was listed with no `pages` entry and could not be
+					// tested. The double-quoted variant was written as
+					// '%[formidable id=\"' inside a SINGLE-quoted PHP string,
+					// where \" is a literal backslash, so it searched for
+					// `id=\"N\"` and could never match real post content.
+					//
+					// Anchoring the block pattern on `{` is safe: FrmSimpleBlocks
+					// Controller registers `formId` first as 'type' => 'string',
+					// and Gutenberg serializes comment attributes in registered-
+					// schema order.
+					//
+					// Each pattern self-disambiguates by ID (closing `]`, trailing
+					// space, or closing quote), so form 12 does not match content
+					// referencing form 123. Only the integer `frm_forms.id` is
+					// interpolated, so no esc_like() handling is needed.
 					// WPDBPREPARE.
 					$form_pages = $wpdb->get_results(
 						$wpdb->prepare(
 							"SELECT ID, post_type FROM {$wpdb->prefix}posts
-						WHERE 1=1 
+						WHERE 1=1
 						AND (
-							post_content LIKE %s 
+							post_content LIKE %s
 							OR post_content LIKE %s
-						) 
-						AND post_status = 'publish' 
+							OR post_content LIKE %s
+							OR post_content LIKE %s
+							OR post_content LIKE %s
+						)
+						AND post_status = 'publish'
 						AND post_type NOT IN ('kadence_wootemplate', 'kadence_element', 'revision')",
-							'%[formidable id=\"' . $row->id . '\"%',
-							'%[formidable id=' . $row->id . ']%'
+							'%[formidable id=' . $row->id . ']%',
+							'%[formidable id=' . $row->id . ' %',
+							'%[formidable id="' . $row->id . '"%',
+							"%[formidable id='" . $row->id . "'%",
+							'%wp:formidable/simple-form {"formId":"' . $row->id . '"%'
 						)
 					);
 					if ( $form_pages ) {


### PR DESCRIPTION
## Symptom

A Formidable form placed with the **block editor**, or with the shortcode **copied from Formidable's own UI**, appears in the CheckView forms list with its name and ID but **no `pages` entry** — so there is no URL to test against.

The form looks supported. It just can't be tested.

## Root cause

Formidable can place a form five ways. `checkview_get_available_forms_list()` matched one:

| Placement | Before |
|---|---|
| `[formidable id=N]` | ✅ |
| `[formidable id=N title=false]` (extra attributes) | ❌ |
| `[formidable id="N"]` — what [Formidable's UI emits](https://github.com/formidableforms) (`FrmFormsController.php:3726`) | ❌ |
| `[formidable id='N']` | ❌ |
| `<!-- wp:formidable/simple-form {"formId":"N"} -->` | ❌ |

The double-quoted pattern was written as:

```php
'%[formidable id=\"' . $row->id . '\"%'
```

That is a **single-quoted** PHP string, where `\"` is not an escape — it's a literal backslash. The query therefore searched `post_content` for `id=\"N\"` and could never match real content. Confirmed by execution rather than inspection:

```
pattern as PHP sees it : [%[formidable id=\"123\"%]
[formidable id="123"]  : *** NO MATCH ***
```

The Gutenberg block was never searched at all — unlike GF, Fluent, NF, WS Form, Everest and Forminator, which all search theirs.

## The fix

Replace the two patterns with the five that mirror Formidable's own reference detection, [`FrmFormsListHelper::get_base_search_strings_for_form()`](https://plugins.trac.wordpress.org/browser/formidable/trunk/classes/helpers/FrmFormsListHelper.php), verified against **Formidable 6.33.1**.

Mirroring upstream is deliberate: if Formidable ever changes its placement syntax, this breaks *identically to Formidable's own "where is this form used" feature*, which makes it a diagnosable upstream change rather than a CheckView-specific mystery.

**Anchoring the block pattern on `{` is safe.** `FrmSimpleBlocksController` registers `formId` **first** with `'type' => 'string'`, and Gutenberg's `getCommentAttributes()` serializes in registered-schema order — not user-set order. So `{"formId":"` is a stable prefix, and the value is quoted rather than numeric.

## Verification

**22 executed assertions, 0 failures.** The harness extracts the pattern literals **from this file** and evaluates them, so it cannot drift from the implementation, then emulates SQL `LIKE` (`%` → `.*`, `_` → `.`):

- all five placements discovered, plus a block with additional attributes
- **no cross-ID false positives** — form `12` does not match form-`123` content in any of the five shapes, and vice versa. Each pattern self-disambiguates via the closing `]`, the trailing space, or the closing quote. Worth checking: a naive prefix match would have silently attributed form 123's pages to form 12.
- unrelated content and a *Gravity Forms* block for the same ID are not matched
- regression assertions confirm the previous patterns genuinely missed cases 2–5 while matching case 1

Not executed: a live WordPress query. The `LIKE` emulation is faithful here because none of the five patterns contain `%` or `_` outside the intended wildcards, but this has not yet been run against a real site. The repo's PHPUnit suite doesn't run from a normal checkout (`tests/bootstrap.php` resolves WP via `dirname(__DIR__, 4)`; `.wp-env.json` sets `testsEnvironment: false`; CI runs SVN update checkers), so this follows the executed-assertion precedent from #225 and #227.

## Security

Only the integer `frm_forms.id` is interpolated, so no `esc_like()` handling is required.

**Key-based shortcodes (`[formidable key="..."]`) are deliberately out of scope.** `form_key` is user-controlled, and `%`/`_` are `LIKE` wildcards — a form keyed `a%b` would broaden the match to unrelated posts. That needs `$wpdb->esc_like()`, which is used **nowhere** in this codebase today. Formidable's own detection doesn't search keys either. Worth handling deliberately rather than incidentally.

## Deployment note

Results are cached in `checkview_forms_list_transient` for **12 hours**. Existing sites will not see newly-discoverable forms until expiry or a manual **Update Cache** (admin settings → `checkview_reset_cache`). Worth knowing before anyone reports "the fix didn't work."

## Scope

Deliberately **additive only** — this finds strictly more and removes nothing.

Excluding templates (`is_template=1`) and repeater child forms (`parent_form_id>0`) is a related but *opposite* change: it removes forms from the list, and if the SaaS holds saved tests against those IDs they could orphan. Different risk profile, separate PR.

## Also found, not fixed here

**Ninja Forms has the identical literal-backslash bug** at `class-checkview-api.php:1368`:

```php
'%wp:ninja-forms/form {\"formID\":' . $row->id . '%'
```

Confirmed by execution — it resolves to `{\"formID\":7` and never matches a real NF block. Out of scope for a Formidable PR; raising it so it isn't lost.

## Base

Based on current `development` (1 ahead, 0 behind — no rebase needed). Does not touch `class-checkview-formidable-helper.php` or `checkview-functions.php`, so **no conflict with #197**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
