### PR TITLE
fix(ninja-forms): discover forms placed with the block editor or plural shortcode

### DIFF
--- a/includes/API/class-checkview-api.php
+++ b/includes/API/class-checkview-api.php
@@ -1352,23 +1352,62 @@ class CheckView_Api {
 						'ID'   => $row->id,
 						'Name' => $row->title,
 					);
+					// Verified against Ninja Forms 3.14.11.
+					//
+					// The block pattern was written as '{\"formID\":' inside a
+					// SINGLE-quoted PHP string, where \" is a literal backslash,
+					// so it searched post_content for `{\"formID\":N` and could
+					// never match a real block.
+					//
+					// Its `formID` attribute is registered as 'type' => 'integer'
+					// (build/form-block.js block.json), so it serialises UNQUOTED:
+					//
+					//   <!-- wp:ninja-forms/form {"formID":7} /-->
+					//   <!-- wp:ninja-forms/form {"formID":7,"formTitle":"..."} /-->
+					//
+					// Unlike Gravity Forms and Formidable — whose formId is a
+					// quoted string, and whose closing quote bounds the value —
+					// an unquoted integer has no terminator. Simply removing the
+					// stray backslashes would make form 7 match forms 71 and 712.
+					// The two patterns below bound the value with `}` (formID is
+					// the only attribute) or `,` (further attributes follow),
+					// which are the only two characters that can legally end a
+					// JSON integer here.
+					//
+					// `formTitle` is declared after `formID`, and Gutenberg
+					// serialises comment attributes in registered-schema order,
+					// so `{"formID":` is a stable prefix.
+					//
+					// Ninja Forms also registers `ninja_forms` (plural) as a
+					// shortcode alias, and the block's own `deprecated` entry
+					// saved `[ninja_forms id=N]` — so that spelling exists in
+					// real post content on sites that used the older block and
+					// was never matched.
 					// WPDBPREPARE.
 					$form_pages = $wpdb->get_results(
 						$wpdb->prepare(
-							"SELECT * FROM {$wpdb->prefix}posts 
-						WHERE 1=1 
+							"SELECT * FROM {$wpdb->prefix}posts
+						WHERE 1=1
 						AND (
-							post_content LIKE %s 
-							OR post_content LIKE %s 
-							OR post_content LIKE %s 
+							post_content LIKE %s
 							OR post_content LIKE %s
-						) 
-						AND post_status = 'publish' 
+							OR post_content LIKE %s
+							OR post_content LIKE %s
+							OR post_content LIKE %s
+							OR post_content LIKE %s
+							OR post_content LIKE %s
+							OR post_content LIKE %s
+						)
+						AND post_status = 'publish'
 						AND post_type NOT IN ('kadence_wootemplate', 'kadence_element', 'revision')",
-							'%wp:ninja-forms/form {\"formID\":' . $row->id . '%',
+							'%wp:ninja-forms/form {"formID":' . $row->id . '}%',
+							'%wp:ninja-forms/form {"formID":' . $row->id . ',%',
 							'%[ninja_form id="' . $row->id . '"]%',
 							'%[ninja_form id=' . $row->id . ']%',
-							'%[ninja_form id=\'' . $row->id . '\']%'
+							"%[ninja_form id='" . $row->id . "']%",
+							'%[ninja_forms id="' . $row->id . '"]%',
+							'%[ninja_forms id=' . $row->id . ']%',
+							"%[ninja_forms id='" . $row->id . "']%"
 						)
 					);
 					if ( $form_pages ) {

--- a/includes/API/class-checkview-api.php
+++ b/includes/API/class-checkview-api.php
@@ -1378,6 +1378,14 @@ class CheckView_Api {
 					// serialises comment attributes in registered-schema order,
 					// so `{"formID":` is a stable prefix.
 					//
+					// The quoted variants no longer require a closing `]`, and the
+					// bare variant carries BOTH terminators — `]` for the end of
+					// the shortcode and a space for further attributes. Ninja
+					// Forms ignores extra attributes but WordPress still renders
+					// them, so `[ninja_form id=12 title="x"]` is valid content
+					// that a `]`-only pattern silently missed. The ID stays
+					// bounded either way, so form 12 cannot match form 123.
+					//
 					// Ninja Forms also registers `ninja_forms` (plural) as a
 					// shortcode alias, and the block's own `deprecated` entry
 					// saved `[ninja_forms id=N]` — so that spelling exists in
@@ -1397,17 +1405,21 @@ class CheckView_Api {
 							OR post_content LIKE %s
 							OR post_content LIKE %s
 							OR post_content LIKE %s
+							OR post_content LIKE %s
+							OR post_content LIKE %s
 						)
 						AND post_status = 'publish'
 						AND post_type NOT IN ('kadence_wootemplate', 'kadence_element', 'revision')",
 							'%wp:ninja-forms/form {"formID":' . $row->id . '}%',
 							'%wp:ninja-forms/form {"formID":' . $row->id . ',%',
-							'%[ninja_form id="' . $row->id . '"]%',
+							'%[ninja_form id="' . $row->id . '"%',
 							'%[ninja_form id=' . $row->id . ']%',
-							"%[ninja_form id='" . $row->id . "']%",
-							'%[ninja_forms id="' . $row->id . '"]%',
+							'%[ninja_form id=' . $row->id . ' %',
+							"%[ninja_form id='" . $row->id . "'%",
+							'%[ninja_forms id="' . $row->id . '"%',
 							'%[ninja_forms id=' . $row->id . ']%',
-							"%[ninja_forms id='" . $row->id . "']%"
+							'%[ninja_forms id=' . $row->id . ' %',
+							"%[ninja_forms id='" . $row->id . "'%"
 						)
 					);
 					if ( $form_pages ) {


### PR DESCRIPTION
Same class of bug as #229, found while verifying that one. Independent — the two touch different regions of `class-checkview-api.php` and apply cleanly together (verified).

## Root cause

```php
'%wp:ninja-forms/form {\"formID\":' . $row->id . '%'
```

A **single-quoted** PHP string, where `\"` is not an escape — it's a literal backslash. The query searched `post_content` for `{\"formID\":N` and could never match a real block.

Ninja Forms' block is **dynamic** (`save: () => null`), so a placed form leaves only the comment delimiter in `post_content`. With the block pattern dead, a form placed via the block editor was returned in the forms list with no `pages` entry — visible in the UI, impossible to test.

## Deleting the backslashes alone would have been wrong

This is the part worth reviewing carefully. `formID` is registered as **`'type' => 'integer'`** (`build/form-block.js` block.json), so it serialises **unquoted**:

```
<!-- wp:ninja-forms/form {"formID":7} /-->
<!-- wp:ninja-forms/form {"formID":7,"formTitle":"Contact"} /-->
```

Gravity Forms and Formidable quote their `formId`, and the **closing quote bounds the value**. An unquoted integer has no terminator — so a naive `{"formID":7` pattern also matches forms **71** and **712**, silently attributing another form's pages to this one. That's a worse failure than the bug being fixed: wrong data rather than missing data.

The two block patterns bound the value with `}` (formID is the only attribute) or `,` (further attributes follow) — the only two characters that can legally terminate a JSON integer in that position.

There's an explicit assertion in the verification for this, so the trap is documented rather than just avoided:

```
ok: NAIVE backslash-only fix WOULD have matched form 712 (why anchoring is needed)
```

`formTitle` is declared after `formID` and Gutenberg serialises comment attributes in registered-schema order, so `{"formID":` is a stable prefix.

## Also: the plural shortcode alias

Ninja Forms registers **four** shortcodes (`includes/Display/Shortcodes.php`): `nf_preview`, `ninja_form`, `ninja_forms`, `ninja_forms_display_form`. We matched only `ninja_form`.

`ninja_forms` (plural) matters because the block's own `deprecated` entry **saved** `[ninja_forms id=N]` into post content:

```js
deprecated:[{ ..., save: function(r){ var o="[ninja_forms id="+parseInt(t)+"]"; ... } }]
```

So that spelling exists in real saved content on any site that used the older block, and was never matched. Added in all three quoting variants for consistency with the singular.

`ninja_forms_display_form` is deliberately **not** matched — it's a registered alias with no known emitter writing it into saved content. Asserted explicitly so the omission is intentional rather than accidental.

## Verification

**26 executed assertions, 0 failures**, against **Ninja Forms 3.14.11**. The harness extracts the pattern literals **from this file** and evaluates them, so it cannot drift from the implementation, then emulates SQL `LIKE`:

- all eight placements discovered, including the deprecated block's `<div>[ninja_forms id=N]</div>` output
- **no cross-ID false positives** — form 7 vs 70/71/712, in both directions, for both block shapes
- a Gravity Forms *and* a Formidable block for the same ID are not matched
- regression assertions confirm the old patterns missed the block entirely and missed the plural alias, while still matching the singular shortcode
- the naive-fix trap asserted explicitly

Not executed: a live WordPress query. Same constraint as #229 — the repo's PHPUnit suite doesn't run from a normal checkout, so this follows the executed-assertion precedent from #225 and #227.

## Security

Only the integer `nf3_forms.id` is interpolated, so no `esc_like()` handling is required.

## Deployment note

Results are cached in `checkview_forms_list_transient` for **12 hours**. Existing sites won't see newly-discoverable forms until expiry or a manual **Update Cache** (admin settings → `checkview_reset_cache`).

## Scope

Additive only — finds strictly more, removes nothing.

Found by source audit, not a customer report. It's a silent failure: no error, no failed test, just a form that can't be selected for testing — so it would not generate a support ticket.

## Base

Based on current `development`. Touches only `class-checkview-api.php`, in a different region than #229 — verified the two apply cleanly together. No conflict with #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
