### PR TITLE
fix(api): bound shortcode form IDs for Gravity Forms, Fluent Forms and WS Form

### DIFF
--- a/includes/API/class-checkview-api.php
+++ b/includes/API/class-checkview-api.php
@@ -1260,9 +1260,19 @@ class CheckView_Api {
 						AND post_status = 'publish' 
 						AND post_type NOT IN ('kadence_wootemplate', 'kadence_element', 'revision')",
 							'%wp:gravityforms/form {"formId":"' . $row->id . '"%',
+							// The unquoted shortcode pattern was unterminated, so
+							// form 12 also matched [gravityform id=123] and
+							// silently inherited that form's pages. The two slots
+							// below previously held byte-identical duplicates, so
+							// both terminators fit without changing the
+							// placeholder count: `]` ends the shortcode, a space
+							// means further attributes follow (title, description,
+							// ajax, tabindex, field_values, theme). Either way the
+							// ID is bounded. The quoted variant above is already
+							// bounded by its closing quote.
 							'%[gravityform id="' . $row->id . '"%',
-							'%[gravityform id=' . $row->id . '%',
-							'%[gravityform id=' . $row->id . '%'
+							'%[gravityform id=' . $row->id . ']%',
+							'%[gravityform id=' . $row->id . ' %'
 						)
 					);
 					if ( $form_pages ) {
@@ -1314,9 +1324,21 @@ class CheckView_Api {
 						AND post_status = 'publish' 
 						AND post_type NOT IN ('kadence_wootemplate', 'kadence_element', 'revision')",
 							'%wp:fluentfom/guten-block {"formId":"' . $row->id . '"%',
+							// The unquoted shortcode pattern was unterminated, so
+							// form 12 also matched [fluentform id=123] and
+							// silently inherited that form's pages. The two slots
+							// below previously held byte-identical duplicates, so
+							// both terminators fit without changing the
+							// placeholder count: `]` ends the shortcode, a space
+							// means further attributes follow (Fluent merges its
+							// defaults through shortcode_atts() with the
+							// `fluentform/shortcode_defaults` filter, so the
+							// accepted set is open-ended). Either way the ID is
+							// bounded. The quoted variant above is already bounded
+							// by its closing quote.
 							'%[fluentform id="' . $row->id . '"%',
-							'%[fluentform id=' . $row->id . '%',
-							'%[fluentform id=' . $row->id . '%'
+							'%[fluentform id=' . $row->id . ']%',
+							'%[fluentform id=' . $row->id . ' %'
 						)
 					);
 					foreach ( $form_pages as $form_page ) {
@@ -1571,9 +1593,21 @@ class CheckView_Api {
 						AND post_status = 'publish' 
 						AND post_type NOT IN ('kadence_wootemplate', 'kadence_element', 'revision')",
 							'%wp:wsf-block/form-add {"form_id":"' . $row->id . '"%',
+							// The unquoted shortcode pattern was unterminated, so
+							// form 12 also matched [ws_form id=123] and silently
+							// inherited that form's pages. The two slots below
+							// previously held byte-identical duplicates, so both
+							// terminators fit without changing the placeholder
+							// count: `]` ends the shortcode, a space means further
+							// attributes follow (element, element_id, class,
+							// published, preview, form_html and field_<id>
+							// population attrs — see
+							// WS_Form_Public::shortcode_ws_form). Either way the
+							// ID is bounded. The quoted variant above is already
+							// bounded by its closing quote.
 							'%[ws_form id="' . $row->id . '"%',
-							'%[ws_form id=' . $row->id . '%',
-							'%[ws_form id=' . $row->id . '%'
+							'%[ws_form id=' . $row->id . ']%',
+							'%[ws_form id=' . $row->id . ' %'
 						)
 					);
 					foreach ( $form_pages as $form_page ) {


### PR DESCRIPTION
Completes the discovery audit from #229 / #230 / #231.

**I previously cleared these three as correct. That was wrong** — I only checked their *block* patterns. Their bare *shortcode* patterns carry the same unterminated-ID collision just fixed for Forminator and Everest in #231.

## The bug

```php
'%[gravityform id=' . $row->id . '%'
'%[fluentform id='  . $row->id . '%'
'%[ws_form id='     . $row->id . '%'
```

No terminator — so form 12 also matches `[gravityform id=123]` and silently inherits that form's pages.

Like Forminator and Everest, this attributes the **wrong** pages to a form rather than finding none. A test can run against a different form's page. That makes it higher priority than #229/#230, which only caused forms to be undiscoverable. Confirmed by execution:

```
Gravity Forms  form 12 vs [gravityform id=123] : *** FALSE POSITIVE ***
Fluent Forms   form 12 vs [fluentform id=123]  : *** FALSE POSITIVE ***
WS Form        form 12 vs [ws_form id=123]     : *** FALSE POSITIVE ***
```

## The fix — zero placeholder churn

Each of the three carried **two byte-identical duplicate copies** of the unquoted pattern. Both terminators fit into the existing slots with **no change to any SQL placeholder count**:

- `]` — the shortcode ends
- ` ` — further attributes follow

Both bound the ID. Quoted variants were already bounded by their closing quote and are unchanged; all three **block** patterns are untouched.

## Why the space terminator is required, not decorative

#231's first revision got this wrong — requiring only `]` fixed the collision but dropped placements carrying extra attributes. All three shortcodes here accept them:

- **WS Form** — `element`, `element_id`, `class`, `published`, `preview`, `form_html`, plus `field_<id>` population attrs (`WS_Form_Public::shortcode_ws_form`, verified against 1.11.19)
- **Fluent Forms** — merged via `shortcode_atts()` through the `fluentform/shortcode_defaults` filter, so the accepted set is open-ended (verified against 6.2.9)
- **Gravity Forms** — `title`, `description`, `ajax`, `tabindex`, `field_values`, `theme`

**Gravity Forms is commercial and not on wordpress.org**, so unlike every other plugin in this series I could not verify its attribute list from source. Stating that plainly rather than implying I did. It doesn't weaken the fix: carrying both terminators is correct either way — if extra attributes are accepted, the space variant matches them; if they aren't, it simply never matches. The `]` variant alone would have been the risky choice.

## Verification

**36 executed assertions, 0 failures.** The harness extracts pattern literals **from this file** and evaluates them, so it cannot drift from the implementation, then emulates SQL `LIKE`:

- bare, bare-with-attributes, and quoted placements all discovered
- blocks still discovered (guards against collateral damage — this PR shouldn't touch them)
- no cross-ID false positives: 12 vs 123, and vs a 4-digit ID sharing the prefix
- cross-plugin isolation
- a regression assertion per plugin confirming the collision really fired before

Worth noting the harness caught a mistake of mine mid-review: my first marker strings under-collected patterns for Fluent (`fluentfom`, upstream's own typo) and WS Form (`wsf-block`), and the pattern-count assertion failed rather than silently testing 3 of 4 patterns. That count assertion is why it's there.

Not executed: a live WordPress query — same constraint as the others.

## Security

Only integer form IDs are interpolated; no `esc_like()` handling required.

## Deployment note

Results cache in `checkview_forms_list_transient` for **12 hours**. As with #231, existing cached lists contain wrong attributions, so clearing the cache after deploy is functional rather than cosmetic.

## Base

Current `development`. Verified #229, #230 and #231 all still apply cleanly alongside. No conflict with #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
