### PR TITLE
fix(formidable): guard the clone handler against child, draft and duplicate entries

### DIFF
--- a/includes/formhelpers/class-checkview-formidable-helper.php
+++ b/includes/formhelpers/class-checkview-formidable-helper.php
@@ -184,6 +184,26 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 		public function checkview_log_form_test_entry( $entry_id, $form_id, $args = array() ) {
 			global $wpdb;
 
+			$entry_id = (int) $entry_id;
+			$form_id  = (int) $form_id;
+
+			// Refuse a non-positive entry id before anything else touches the
+			// database. This is not defensive tidiness — the child-entry cleanup
+			// below queries `WHERE parent_item_id = %d`, and Formidable stores 0
+			// in that column for every TOP-LEVEL entry
+			// (FrmMigrate.php:234: `parent_item_id BIGINT(20) default 0`). So an
+			// entry_id of 0 would select the customer's entire entry table and
+			// then delete it.
+			//
+			// Formidable core cannot pass 0 here — the action fires with a real
+			// insert id — but the previous code was a harmless no-op in that case
+			// and the child cleanup made it destructive, so the invariant is now
+			// enforced rather than assumed.
+			if ( $entry_id <= 0 ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Formidable submission hook fired with a non-positive entry id [' . $entry_id . ']; refusing to touch the database.' );
+				return;
+			}
+
 			// Child entries: `frm_after_create_entry` also fires for repeater
 			// and embedded-form child entries, passing compact( 'is_child' )
 			// (FrmEntry::after_entry_created_actions). Without this guard a form

--- a/includes/formhelpers/class-checkview-formidable-helper.php
+++ b/includes/formhelpers/class-checkview-formidable-helper.php
@@ -64,6 +64,9 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 				2
 			);
 
+			// Accepts 3 args: Formidable passes compact( 'is_child' ) as the
+			// third (FrmEntry::after_entry_created_actions), which the handler
+			// needs to skip repeater/embedded-form child entries.
 			add_action(
 				'frm_after_create_entry',
 				array(
@@ -71,7 +74,7 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 					'checkview_log_form_test_entry',
 				),
 				99,
-				2
+				3
 			);
 
 			add_filter(
@@ -178,8 +181,47 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 		 * @param int $form_id Form entry ID.
 		 * @return void
 		 */
-		public function checkview_log_form_test_entry( $entry_id, $form_id ) {
+		public function checkview_log_form_test_entry( $entry_id, $form_id, $args = array() ) {
 			global $wpdb;
+
+			// Child entries: `frm_after_create_entry` also fires for repeater
+			// and embedded-form child entries, passing compact( 'is_child' )
+			// (FrmEntry::after_entry_created_actions). Without this guard a form
+			// with a repeater cloned one cv_entry row per child AND called
+			// complete_checkview_test() on the first of them — tearing the
+			// session down before the parent entry was ever cloned, which
+			// surfaces to the SaaS as submission-not-found.
+			if ( ! empty( $args['is_child'] ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Skipping Formidable child entry [' . $entry_id . '] (repeater/embedded form); the parent entry is cloned separately.' );
+				return;
+			}
+
+			// Draft entries: Formidable Pro's "Save Draft" creates a real entry
+			// with is_draft=1 (FrmEntry::get_is_draft_value via the
+			// frm_saving_draft post value) and this action fires for it. Cloning
+			// and completing on a draft ends the test session while the visitor
+			// is still partway through a multi-page form.
+			$is_draft = (int) $wpdb->get_var(
+				$wpdb->prepare( 'SELECT is_draft FROM ' . $wpdb->prefix . 'frm_items WHERE id=%d', $entry_id )
+			);
+			if ( 1 === $is_draft ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Skipping Formidable draft entry [' . $entry_id . ']; waiting for the final submission.' );
+				return;
+			}
+
+			// Idempotence: guards against this handler running twice for the
+			// same entry within one request (a second helper instance, or a
+			// plugin re-firing the action). A repeat would insert a duplicate
+			// cv_entry row and call complete_checkview_test() again after the
+			// session was already torn down. Mirrors the guard in
+			// Checkview_Fluent_Forms_Helper::checkview_clone_fluentform_entry().
+			static $processed = array();
+			$processed_key    = $entry_id . '_' . $form_id;
+			if ( isset( $processed[ $processed_key ] ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Formidable entry [' . $entry_id . '] already cloned in this request; skipping duplicate.' );
+				return;
+			}
+			$processed[ $processed_key ] = true;
 
 			Checkview_Admin_Logs::add( 'ip-logs', 'Cloning submission entry [' . $entry_id . ']...' );
 
@@ -217,8 +259,19 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 				$entry_meta_table = $wpdb->prefix . 'cv_entry_meta';
 				$fields = $this->get_form_fields( $form_id );
 
+				// Previously `return`ed here. That exited the whole method,
+				// skipping BOTH the Formidable entry delete and
+				// complete_checkview_test() below — leaving the test submission
+				// in the customer's database and hanging the test until it timed
+				// out. It also contradicted the comment directly above, which
+				// states that cleanup still runs.
+				//
+				// Fall through with an empty map instead: every row in the meta
+				// loop below is skipped (no matching field definition), and
+				// cleanup proceeds as documented.
 				if ( empty( $fields ) ) {
-					return;
+					Checkview_Admin_Logs::add( 'ip-logs', 'No field definitions found for form [' . $form_id . ']; skipping entry meta clone but continuing cleanup.' );
+					$fields = array();
 				}
 
 				$tablename = $wpdb->prefix . 'frm_item_metas';
@@ -410,13 +463,53 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 				if ( $count > 0 ) {
 					Checkview_Admin_Logs::add( 'ip-logs', 'Cloned submission entry meta data (inserted ' . $count . ' rows into ' . $entry_meta_table . ').' );
 				} else {
-					if ( count( $form_fields ) > 0 ) {
+					// `! empty( $fields )` keeps this from reporting a database
+					// failure when the real cause was no field definitions —
+					// that case is logged above with its actual reason and would
+					// otherwise print an empty wpdb->last_error.
+					if ( count( $form_fields ) > 0 && ! empty( $fields ) ) {
 						Checkview_Admin_Logs::add( 'ip-logs', 'Failed to clone submission entry meta data. wpdb->last_error=[' . $wpdb->last_error . ']' );
 					}
 				}
 			}
 
-			// Remove test entry form Formidable.
+			// Remove test entry from Formidable.
+			//
+			// Child entries first. Repeater and embedded-form rows are separate
+			// frm_items records linked by parent_item_id, and they are now
+			// skipped by the is_child guard at the top of this method — so
+			// unlike before, nothing else deletes them. Without this they would
+			// accumulate in the customer's tables, one set per test run.
+			//
+			// Scoped strictly to children of the entry just cloned, so
+			// attribution is exact: parent_item_id is set by Formidable when it
+			// creates the child and is never guessed here. Metas are removed
+			// before the parent rows so the id list is still resolvable.
+			$child_ids = $wpdb->get_col(
+				$wpdb->prepare( 'SELECT id FROM ' . $wpdb->prefix . 'frm_items WHERE parent_item_id=%d', $entry_id )
+			);
+
+			if ( ! empty( $child_ids ) ) {
+				$child_ids = array_map( 'intval', $child_ids );
+				// Placeholders are generated from the row count, never from a
+				// value; every id is still bound through prepare(), and the ids
+				// themselves came from the database as integers.
+				// WPDBPREPARE.
+				$placeholders = implode( ',', array_fill( 0, count( $child_ids ), '%d' ) );
+
+				$wpdb->query(
+					$wpdb->prepare(
+						'DELETE FROM ' . $wpdb->prefix . 'frm_item_metas WHERE item_id IN (' . $placeholders . ')',
+						$child_ids
+					)
+				);
+				$wpdb->query(
+					$wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . 'frm_items WHERE parent_item_id=%d', $entry_id )
+				);
+
+				Checkview_Admin_Logs::add( 'ip-logs', 'Removed ' . count( $child_ids ) . ' Formidable child entr' . ( 1 === count( $child_ids ) ? 'y' : 'ies' ) . ' of entry [' . $entry_id . '].' );
+			}
+
 			$wpdb->query( $wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . 'frm_item_metas WHERE item_id=%d', $entry_id ) );
 			$wpdb->query( $wpdb->prepare( 'DELETE FROM ' . $wpdb->prefix . 'frm_items WHERE id=%d', $entry_id ) );
 


### PR DESCRIPTION
Four defects in `Checkview_Formidable_Helper::checkview_log_form_test_entry()`, all confirmed by execution rather than inspection.

## Verification approach

These are control-flow bugs, not string patterns, so the harness drives the **real method** from the shipped file against a stubbed `$wpdb` — no WordPress needed. The same harness run against the **current** file reports **17 failures**; against this branch, **29 assertions, 0 failures**. Every claim below has a corresponding failing assertion on `development`.

## 1. Child entries were cloned as submissions

`frm_after_create_entry` also fires for repeater and embedded-form child entries, passing `compact( 'is_child' )` as a **third argument** (`FrmEntry::after_entry_created_actions`) that the handler neither accepted nor checked.

A form with a repeater inserted one `cv_entry` row per child **and** called `complete_checkview_test()` on the first of them — tearing the session down before the parent was ever cloned. That surfaces to the SaaS as `submission-not-found`.

The action is now registered for 3 args and child entries return early.

## 2. Draft entries ended the test mid-flow

Formidable Pro's Save Draft / save-progress creates a real entry with `is_draft=1`, and this action fires for it. The handler cloned it, **deleted it**, and completed the test — destroying the entry the visitor was still filling in. Now skipped.

## 3. No idempotence guard

A second invocation for the same entry in one request inserted a duplicate `cv_entry` row and called `complete_checkview_test()` again after the session was already gone. Mirrors the existing static guard in `Checkview_Fluent_Forms_Helper::checkview_clone_fluentform_entry()`.

## 4. Cleanup could be skipped entirely

```php
if ( empty( $fields ) ) {
    return;      // <- exits the METHOD
}
```

That skipped both the Formidable entry delete and `complete_checkview_test()` — leaving the test submission in the customer's database and hanging the test until timeout. It also **contradicted the comment three lines above it**, which states that cleanup still runs.

Now falls through with an empty map: the meta loop skips every row and cleanup proceeds as documented. The adjacent `Failed to clone submission entry meta data` log is gated on `! empty( $fields )`, so it stops reporting a database failure with an empty `last_error` when the real cause was no field definitions.

## Child-entry cleanup — required by guard 1

Previously each child deleted itself during its own (incorrect) invocation. Now that children are skipped, **nothing else removes them**, so they would accumulate one set per test run. Guard 1 would have traded a session bug for a data leak without this.

Scoped strictly to `parent_item_id` = the entry just cloned, so attribution is exact — Formidable sets that value when it creates the child; it is never inferred here. Metas are removed before the parent rows so the id list is still resolvable, and no `DELETE` is issued when there are no children (asserted: never emits an empty `IN ()`).

Placeholders for the `IN` list are generated from the row count, never from a value, and every id is bound through `prepare()` after `intval()`.

## Deliberately not included

The **clone-early/delete-late restructure and deferred deletion** from the original plan. Deferring adds a window where a real entry sits in the customer's database, plus a stale-cron deletion surface, to solve async-feed orphaning that **nobody has reported**. Every change here is a guard — it can only cause the handler to do less, never more.

Also excluded on purpose: the `complete_checkview_test()` call is **not** moved earlier. It deletes the `allow_original_recipients` flags, and Formidable's email action runs at `frm_after_create_entry` priority 20 — advancing completion past that point would silently degrade #197's append-mode to replace-mode.

## Known limitation, unchanged here

A form using Save Draft still won't produce a result: the final submission **updates** the draft and fires `frm_after_update_entry`, which this helper doesn't hook. Before this change such a test corrupted its own run by deleting the draft mid-flow; now it fails cleanly by timing out. Failing honestly beats passing falsely, but full save-draft support needs the update hook and is a separate change.

## Base

Current `development`. Verified #197 applies cleanly on top — its Formidable hunks are in `checkview_inject_email` / `checkview_remove_email_header`, disjoint from the constructor and clone handler touched here. No conflict with #229–#233 either (different file).

## Still outstanding

No live-site verification. In particular the **child-before-parent ordering** for repeaters is inferred from `is_child` being passed, not observed — the double-clone is certain, the premature-completion sequence is not. Worth confirming in a wp-env repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
