### PR TITLE
fix(formidable): bypass the remaining anti-spam gates during CheckView tests

### DIFF
--- a/includes/formhelpers/class-checkview-formidable-helper.php
+++ b/includes/formhelpers/class-checkview-formidable-helper.php
@@ -111,6 +111,70 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 				'__return_false'
 			);
 
+			// Anti-spam bypass, precise layer.
+			//
+			// Formidable's spam pipeline (FrmEntryValidate::spam_check) has
+			// eight independent gates. Only the honeypot (above) and the
+			// captcha field type (frm_fields_to_validate) were handled. Each
+			// filter below is the documented switch for one gate, verified
+			// against Formidable 6.33.1:
+			//
+			//   frm_run_antispam    FrmAntiSpam::run_antispam() — the token
+			//                       check. Fails closed when the token is
+			//                       missing, which happens on a stale cached
+			//                       page (tokens are only valid +/- 2 days) or
+			//                       when the form is rendered without its JS.
+			//   frm_check_blacklist FrmSpamCheckWPDisallowedWords::is_enabled()
+			//                       — the only gate that is ALWAYS on. It runs
+			//                       wp_check_comment_disallowed_list() over the
+			//                       entry content, the submitting IP and the
+			//                       user agent whenever WordPress's own
+			//                       disallowed_keys option is non-empty, which
+			//                       security plugins routinely populate.
+			//   frm_check_denylist  FrmSpamCheckDenylist::is_enabled() — the
+			//                       Formidable denylist (words, emails, IPs).
+			//
+			// StopForumSpam and the WP-comment-spam check have no enable
+			// filter, and Formidable's Akismet path reads
+			// get_option( 'wordpress_api_key' ) directly rather than going
+			// through `akismet_get_api_key` above — so neither is reachable
+			// from here. Those are caught by the frm_validate_entry backstop
+			// instead.
+			add_filter( 'frm_run_antispam', '__return_false', PHP_INT_MAX );
+			add_filter( 'frm_check_blacklist', '__return_false', PHP_INT_MAX );
+			add_filter( 'frm_check_denylist', '__return_false', PHP_INT_MAX );
+
+			// Bypass hCaptcha. Formidable's own hCaptcha support is the
+			// `captcha` field type already stripped by
+			// remove_recaptcha_field_from_list(), but the standalone
+			// "hCaptcha for WordPress" plugin ships its own Formidable
+			// integration that operates outside that field type. Matches the
+			// GF, WPForms, CF7, Fluent, Everest and Elementor helpers.
+			add_filter( 'hcap_activate', '__return_false' );
+
+			// Anti-spam bypass, backstop layer.
+			//
+			// Single choke point: frm_validate_entry fires AFTER spam_check()
+			// and its return value replaces the error array
+			// (FrmEntryValidate::validate). Clearing $errors['spam'] here
+			// therefore neutralises every gate at once, including the three
+			// that have no filter of their own. Runs at PHP_INT_MAX so it lands
+			// after any third-party callback that might add a spam verdict.
+			//
+			// Both layers are kept deliberately. The filters above are precise
+			// but fail silently if Formidable renames one; this backstop still
+			// catches the resulting error. Same belt-and-braces shape as the GF
+			// helper's explicit reCAPTCHA unhook plus its marker fallback.
+			add_filter(
+				'frm_validate_entry',
+				array(
+					$this,
+					'checkview_bypass_spam_validation',
+				),
+				PHP_INT_MAX,
+				1
+			);
+
 			// Disbale form action.
 			add_filter(
 				'frm_custom_trigger_action',
@@ -549,6 +613,50 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 			}
 			return $fields;
 		}
+		/**
+		 * Clears Formidable's spam verdict during a CheckView test.
+		 *
+		 * `frm_validate_entry` is applied after `FrmEntryValidate::spam_check()`
+		 * and its return value replaces the error array, so this is the one
+		 * place that catches every spam gate — including StopForumSpam, the
+		 * WP-comment-spam check and Akismet, none of which expose a filter this
+		 * helper can switch off directly.
+		 *
+		 * Scoping is provable rather than best-effort. Formidable keys genuine
+		 * field failures as `field<id>` (and `field<id>-<name>` for sub-fields),
+		 * nonce/permission failures as `form`, and uses `message`, `trash` and
+		 * `json` elsewhere. `spam` is written only by `spam_check()`. Removing
+		 * that single key therefore cannot suppress a real validation error, so
+		 * a test still fails honestly when the form genuinely rejects the
+		 * submission — the same principle as
+		 * Checkview_Gforms_Helper::checkview_bypass_captcha_validation(), which
+		 * deliberately keeps non-anti-bot failures.
+		 *
+		 * Only ever registered inside a verified test session: the helper is
+		 * loaded from checkview_init_current_test(), which requires is_bot().
+		 *
+		 * @param array $errors Validation errors keyed by field or reason.
+		 * @return array Errors with any spam verdict removed.
+		 */
+		public function checkview_bypass_spam_validation( $errors ) {
+			if ( ! is_array( $errors ) || ! isset( $errors['spam'] ) ) {
+				return $errors;
+			}
+
+			$message = is_string( $errors['spam'] ) ? $errors['spam'] : '';
+			unset( $errors['spam'] );
+
+			// Log the remaining keys so a genuine failure alongside the spam
+			// verdict stays visible in support logs rather than looking like a
+			// clean pass.
+			Checkview_Admin_Logs::add(
+				'ip-logs',
+				'Cleared Formidable spam verdict during CheckView test. Message was [' . substr( $message, 0, 200 ) . ']. Remaining validation errors: [' . ( empty( $errors ) ? 'none' : implode( ', ', array_keys( $errors ) ) ) . '].'
+			);
+
+			return $errors;
+		}
+
 		/**
 		 * Removes ReCAPTCHA field from form fields and form validation.
 		 *

--- a/includes/formhelpers/class-checkview-formidable-helper.php
+++ b/includes/formhelpers/class-checkview-formidable-helper.php
@@ -152,6 +152,22 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 			// GF, WPForms, CF7, Fluent, Everest and Elementor helpers.
 			add_filter( 'hcap_activate', '__return_false' );
 
+			// Third-party anti-spam plugins that attach their failure to a key
+			// other than `spam`, which the frm_validate_entry backstop below
+			// cannot clear. Registered on `init` at PHP_INT_MAX because WP Armour
+			// includes its integrations from an `init` callback at the DEFAULT
+			// priority (wp-armour.php:17-24), i.e. the same priority this helper
+			// is loaded at — so ordering between the two would otherwise depend
+			// on registration order.
+			add_action(
+				'init',
+				array(
+					$this,
+					'checkview_unhook_third_party_spam_filters',
+				),
+				PHP_INT_MAX
+			);
+
 			// Anti-spam bypass, backstop layer.
 			//
 			// Single choke point: frm_validate_entry fires AFTER spam_check()
@@ -613,6 +629,47 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 			}
 			return $fields;
 		}
+		/**
+		 * Removes third-party anti-spam callbacks that reject a Formidable
+		 * submission through an error key the spam backstop cannot clear.
+		 *
+		 * `checkview_bypass_spam_validation()` unsets only `$errors['spam']`,
+		 * which is correct for Formidable core — core writes field failures as
+		 * `field<id>` and nonce/permission failures as `form`, and only
+		 * `spam_check()` writes `spam`. Third-party plugins are not bound by that
+		 * convention.
+		 *
+		 * WP Armour is the known case. Its Formidable integration hooks
+		 * `frm_validate_entry` at priority 10 and writes `$errors['my_error']`
+		 * (honeypot/includes/integration/wpa_formidable.php:6-14), so the backstop
+		 * runs after it, sees the key and leaves it — the submission still fails.
+		 *
+		 * It is also likely to fire rather than unlikely: `wpa_check_is_spam()`
+		 * (honeypot/includes/wpa_functions.php:136-152) is fails-closed. It
+		 * returns "not spam" only when the POST carries WP Armour's JS-injected
+		 * `alt_s` and named field, and treats anything else as spam. So the usual
+		 * "a headless browser will not fill a hidden honeypot, therefore it
+		 * passes" reasoning is inverted here and does not apply.
+		 *
+		 * Degrades to a logged no-op: nothing removed and no such function means
+		 * the plugin is absent; the function existing but not removable means it
+		 * moved priority or was renamed, which is worth knowing about.
+		 *
+		 * @since 2.3.1
+		 *
+		 * @return void
+		 */
+		public function checkview_unhook_third_party_spam_filters() {
+			if ( remove_filter( 'frm_validate_entry', 'wpa_formidable_extra_validation', 10 ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Unhooked WP Armour from frm_validate_entry for this CheckView test.' );
+				return;
+			}
+
+			if ( function_exists( 'wpa_formidable_extra_validation' ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'WP Armour detected but its frm_validate_entry callback was not removable (priority changed or renamed?) — Formidable submissions may still be rejected as spam.' );
+			}
+		}
+
 		/**
 		 * Clears Formidable's spam verdict during a CheckView test.
 		 *


### PR DESCRIPTION
`FrmEntryValidate::spam_check()` runs **eight** independent gates. The helper handled **two** — the honeypot and the `captcha` field type. The other six could reject a CheckView submission outright, and the resulting failure was reported as an ordinary test failure with nothing indicating spam protection caused it.

Verified against **Formidable 6.33.1**.

## Which gates were unhandled

| Gate | Switch | Default |
|---|---|---|
| WP disallowed words | `frm_check_blacklist` | **always on** |
| Formidable denylist | `frm_check_denylist` | off |
| Anti-spam token | `frm_run_antispam` | off (per form) |
| StopForumSpam | *none* | off (per form) |
| WP comment spam | *none* | off |
| Akismet | *none reachable* | off (per form) |

**The one that matters most is `frm_check_blacklist`.** `FrmSpamCheckWPDisallowedWords::is_enabled()` returns `true` unconditionally, and `check()` runs `wp_check_comment_disallowed_list()` over the entry content, the **submitting IP** and the **user agent** whenever WordPress's own `disallowed_keys` option is non-empty — which security plugins routinely populate. It needs no Formidable setting to fire, so it can bite a customer who never enabled any spam feature.

`frm_run_antispam` matters because the token check **fails closed**: tokens are valid only ±2 days, so a stale cached page or a form rendered without its JS is rejected.

## Two layers, both deliberate

**Precise layer** — the documented switch per gate: `frm_run_antispam`, `frm_check_blacklist`, `frm_check_denylist`, plus `hcap_activate`.

`hcap_activate` matches the GF, WPForms, CF7, Fluent, Everest and Elementor helpers. Formidable's own hCaptcha is the `captcha` field type already stripped by `remove_recaptcha_field_from_list()`, but the standalone *hCaptcha for WordPress* plugin ships a separate Formidable integration that works outside that field type.

**Backstop layer** — `frm_validate_entry` at `PHP_INT_MAX`.

StopForumSpam and the WP-comment-spam check expose no enable filter, and Formidable's Akismet path reads `get_option( 'wordpress_api_key' )` **directly** rather than going through the `akismet_get_api_key` filter this helper already sets — so none of the three is reachable from the precise layer. `frm_validate_entry` fires *after* `spam_check()` and its return replaces the error array, so clearing `$errors['spam']` neutralises all eight gates at once.

Keeping both layers is the point: the individual filters fail **silently** if Formidable renames one, and the backstop still catches the resulting error. Same belt-and-braces shape as the GF helper's explicit reCAPTCHA unhook plus its marker fallback.

## The scoping is provable, not best-effort

I enumerated every `$errors[…]` key Formidable writes:

```
 18  $errors[ 'field' . $args['id'] ]      <- genuine field failures
  5  $errors['spam']                        <- only from spam_check()
  4  $errors['message']
  3  $errors['form']                        <- nonce / permission
  3  $errors[ 'field' . $field_id . '-' . $name ]
  1  $errors['trash'] / ['json'] / ['field' . $field_id]
```

`spam` is written *only* by `spam_check()`. Removing that one key cannot suppress a real validation error, so a test still **fails honestly** when the form genuinely rejects the submission — the same principle as `checkview_bypass_captcha_validation()` in the GF helper, which deliberately keeps non-anti-bot failures. Surviving error keys are logged, so a genuine failure alongside a spam verdict stays visible in support logs instead of looking like a clean pass.

Only ever active inside a verified test session — the helper loads from `checkview_init_current_test()`, which requires `is_bot()`.

## Verification

**33 executed assertions, 0 failures.** The harness registers the **real constructor hooks** into a filter registry and drives the **real method**:

- every gate switch present and returning `false`; backstop registered at `PHP_INT_MAX`
- all seven spam sources cleared
- `field25`, `field3-first`, `form`, `message`, `trash`, `json` all preserved
- a mixed spam-plus-required-field result still fails (the real error is kept)
- non-array input and a non-string spam value handled without error
- logs only when a verdict was actually cleared

The same harness reports **10 failures** against the current file.

Not executed: a live submission against a site with these gates enabled. That remains the outstanding gap across this series.

## What I deliberately left out

`frm_allowed_ips` — it only skips StopForumSpam's *IP* lookup; `check()` still extracts emails and queries the API by email, so it wouldn't avoid the outbound request. And `frm_stopforumspam_api_url` — pointing it at a dead host risks a hang rather than a fast failure. The backstop already covers the verdict; neither filter earns its surface area.

## Base

Current `development`. Verified both #197 and #234 apply cleanly on top — #197's Formidable hunks are in the email functions and #234's are in the clone handler, both disjoint from the constructor and the new method here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
