### PR TITLE
fix(formidable): make the User Registration action honor disable_actions

### DIFF
--- a/includes/formhelpers/class-checkview-formidable-helper.php
+++ b/includes/formhelpers/class-checkview-formidable-helper.php
@@ -577,8 +577,35 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 		 * @param string $event  Event ('create' or 'update').
 		 */
 		function checkview_disable_form_actions( $skip, $action, $entry, $form, $event ) {
-			// Keys to keep.
-			$keys_to_keep = array( 'email', 'register', 'on_submit' );
+			// Action types that always run, regardless of `disable_actions`.
+			//
+			// Only the email action. It is what `assert_email_received` depends
+			// on, so a test cannot verify a notification without it.
+			//
+			// `register` was removed. It is the User Registration add-on's slug
+			// (FrmFormActionsController maps 'register' => 'user-registration'),
+			// so keeping it here meant every test on a registration form created
+			// a real WordPress user account — and did so even when the SaaS had
+			// explicitly asked for actions to be disabled, because this
+			// allowlist short-circuits the `disable_actions` check below. It now
+			// honours that flag: skipped when actions are disabled, still run
+			// when the customer opts integrations in.
+			//
+			// Formidable was the only helper keeping a user-creating action.
+			// Gravity Forms returns an empty feed array (dropping User
+			// Registration with everything else), WS Form keeps only
+			// database/message/email, and Fluent Forms keeps only its
+			// `notifications` feed. Note `wppost` (Create WordPress Post) was
+			// already absent from this list, so post creation was disabled while
+			// user creation was not.
+			//
+			// `on_submit` was removed as dead weight, not as a behaviour change.
+			// Formidable core skips that action earlier in the same loop
+			// (FrmFormActionsController: `|| FrmOnSubmitAction::$slug ===
+			// $action->post_excerpt`), so it never reaches this filter.
+			// Confirmation and redirect behaviour is applied at render time, not
+			// through the action trigger.
+			$keys_to_keep = array( 'email' );
 			if ( in_array( $action->post_excerpt, $keys_to_keep, true ) ) {
 				return false;
 			}


### PR DESCRIPTION
```php
$keys_to_keep = array( 'email', 'register', 'on_submit' );
if ( in_array( $action->post_excerpt, $keys_to_keep, true ) ) {
    return false;   // <- runs, before disable_actions is ever consulted
}
```

That allowlist **short-circuits the `disable_actions` check below it**, so every entry ran regardless of what the SaaS asked for.

`register` is the User Registration add-on's slug — `FrmFormActionsController` maps `'register' => 'user-registration'`. So a CheckView test on a registration form **created a real WordPress user account, one per run**, even when the test explicitly requested that actions be disabled.

This is less a policy change than honouring a flag that was being ignored. `register` now follows `disable_actions` like everything else: skipped when actions are disabled (the default for tests), still run when the customer opts integrations in.

## Formidable was the only helper doing this

| Helper | Behaviour with actions disabled |
|---|---|
| Gravity Forms | returns `array()` from `gform_addon_pre_process_feeds` — drops User Registration with everything else |
| WS Form | keeps only `database`, `message`, `email` |
| Fluent Forms | keeps only the `notifications` feed |
| **Formidable (before)** | kept `email`, **`register`**, `on_submit` |

Worth noting `wppost` (Create WordPress Post) was **already absent** from the list, so post creation was disabled while *user* creation was not. That reads as an oversight rather than an intent.

## What stays and what goes

**`email` stays unconditional** — `assert_email_received` depends on it, so a test can't verify a notification without it.

**`on_submit` is removed as dead weight, not a behaviour change.** Formidable core skips that action earlier in the same loop (`|| FrmOnSubmitAction::$slug === $action->post_excerpt`), so it never reaches this filter. Confirmation and redirect behaviour is applied at render time, not through the action trigger.

## Verification

**14 executed assertions, 0 failures**, driving the real method — and accounting for the filter's **inverted contract**: Formidable runs the action when the callback returns `false` (`if ( false === apply_filters( 'frm_custom_trigger_action', false, … ) )`), so `true` means skipped.

- actions disabled → `email` runs; `register`, `wppost`, and third-party actions skipped
- actions enabled → everything runs, `register` included
- no test session → nothing skipped, so the filter **fails open**
- logging names a skipped action and stays quiet for an allowed one
- a source assertion pins the keep list at exactly `['email']`, so a future edit can't quietly re-add an entry

The same harness reports **3 failures** against the current file.

## Trade-off, stated plainly

A test that signs up a user and asserts a *welcome* email may stop seeing that email if the add-on sends it from the register action rather than the separate `email` action. **I could not verify this** — User Registration is a paid add-on and isn't in the wordpress.org distribution. Customers who want that coverage can opt integrations in, which now actually works as intended.

If it turns out the welcome mail does come from the register action and that coverage matters, the follow-up would be cleanup-on-create rather than reinstating the allowlist bypass — attribution of created users is doable but fragile, so I'd want a real case before building it.

## Base

Current `development`. Verified #197, #234 and #235 all apply cleanly on top — this touches only `checkview_disable_form_actions`, which none of them modify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
