### PR TITLE
fix(gf,fluent): unhook WP Armour, which neither helper's spam bypass can stop

### DIFF
--- a/includes/formhelpers/class-checkview-fluent-forms-helper.php
+++ b/includes/formhelpers/class-checkview-fluent-forms-helper.php
@@ -138,6 +138,33 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 			// Bypass hCaptcha.
 			add_filter( 'hcap_activate', '__return_false' );
 
+			// WP Armour — Honeypot Anti Spam.
+			//
+			// Unlike every other anti-spam integration this helper handles, WP
+			// Armour's Fluent Forms callback cannot be neutralised by any filter:
+			// on a spam verdict it calls wp_send_json_error() and wp_die()
+			// (honeypot/includes/integration/wpa_fluentform.php:6-14), terminating
+			// the request. There is no return value to override, so unhooking is
+			// the only remedy.
+			//
+			// It is also registered OUTSIDE WP Armour's `! is_admin()` gate
+			// (wp-armour.php:30), so unlike its Gravity Forms and Formidable
+			// integrations it fires on admin-ajax — which is exactly where Fluent
+			// Forms submits.
+			//
+			// Its check fails closed: wpa_check_is_spam()
+			// (honeypot/includes/wpa_functions.php:136-153) treats a submission as
+			// spam UNLESS it carries WP Armour's JS-injected fields.
+			//
+			// Registered on `init` at PHP_INT_MAX because WP Armour includes its
+			// integrations from an `init` callback at the default priority
+			// (wp-armour.php:17-32), the same priority this helper is loaded at.
+			add_action(
+				'init',
+				array( $this, 'checkview_unhook_wp_armour' ),
+				PHP_INT_MAX
+			);
+
 			// Bypass Akismet.
 			add_filter(
 				'akismet_get_api_key',
@@ -195,6 +222,40 @@ if ( ! class_exists( 'Checkview_Fluent_Forms_Helper' ) ) {
 				array($this, 'static_ids'),
 				99
 			);
+		}
+
+		/**
+		 * Removes WP Armour's Fluent Forms submission callback for this request.
+		 *
+		 * Both hook spellings are attempted. WP Armour currently registers the
+		 * slash-style `fluentform/before_insert_submission` and leaves the legacy
+		 * underscore spelling commented out, but Fluent renamed these hooks at
+		 * 4.3.22 and WP Armour has shipped both, so removing either is cheap
+		 * insurance.
+		 *
+		 * Degrades to a logged no-op.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @return void
+		 */
+		public function checkview_unhook_wp_armour() {
+			$removed = 0;
+
+			foreach ( array( 'fluentform/before_insert_submission', 'fluentform_before_insert_submission' ) as $hook ) {
+				if ( remove_action( $hook, 'wpa_fluent_form_extra_validation', 10 ) ) {
+					++$removed;
+				}
+			}
+
+			if ( $removed > 0 ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Unhooked WP Armour from [' . $removed . '] Fluent Forms submission hook(s) for this CheckView test.' );
+				return;
+			}
+
+			if ( function_exists( 'wpa_fluent_form_extra_validation' ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'WP Armour detected but its Fluent Forms callback was not removable (priority changed or renamed?) — submissions may still be terminated as spam.' );
+			}
 		}
 
 		/**

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -261,6 +261,35 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 				'hcap_activate',
 				'__return_false'
 			);
+
+			// WP Armour — Honeypot Anti Spam.
+			//
+			// Its GF integration hooks `gform_validation` at priority 10 and, on a
+			// spam verdict, sets is_valid = false and attaches the failure to
+			// `$form['fields'][0]` with the configurable `wpa_error_message`
+			// (honeypot/includes/integration/wpa_gravityforms.php:6-17).
+			//
+			// checkview_bypass_captcha_validation() below cannot clear that. Field
+			// [0] is whatever the form's first field happens to be, so the type
+			// allowlist does not match, and the default message —
+			// " Spamming or your Javascript is disabled !!" — contains none of the
+			// markers in `checkview_anti_bot_validation_markers`. Adding a marker
+			// would not be reliable either: the message is a site option the owner
+			// can rewrite to anything.
+			//
+			// Its check also FAILS CLOSED — wpa_check_is_spam()
+			// (honeypot/includes/wpa_functions.php:136-153) treats a submission as
+			// spam UNLESS it carries WP Armour's JS-injected fields — so the
+			// failure mode is a hard block, not a soft one.
+			//
+			// Registered on `init` at PHP_INT_MAX because WP Armour includes its
+			// integrations from an `init` callback at the default priority
+			// (wp-armour.php:17-24), the same priority this helper is loaded at.
+			add_action(
+				'init',
+				array( $this, 'checkview_unhook_wp_armour' ),
+				PHP_INT_MAX
+			);
 			// Bypass Akismet.
 			add_filter(
 				'akismet_get_api_key',
@@ -278,6 +307,33 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 				PHP_INT_MAX
 			);
 		}
+		/**
+		 * Removes WP Armour's Gravity Forms validation callback for this request.
+		 *
+		 * Explicit unhook rather than a message marker, because the failure it
+		 * raises is indistinguishable from a genuine one: it lands on an arbitrary
+		 * field and carries an operator-configurable message. Mirrors
+		 * unhook_gf_recaptcha_addon().
+		 *
+		 * Degrades to a logged no-op — nothing removed and no such function means
+		 * the plugin is absent; the function present but not removable means it
+		 * changed priority or was renamed, which is worth surfacing.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @return void
+		 */
+		public function checkview_unhook_wp_armour() {
+			if ( remove_action( 'gform_validation', 'wpa_gravityforms_extra_validation', 10 ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Unhooked WP Armour from gform_validation for this CheckView test.' );
+				return;
+			}
+
+			if ( function_exists( 'wpa_gravityforms_extra_validation' ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'WP Armour detected but its gform_validation callback was not removable (priority changed or renamed?) — GF submissions may still be rejected as spam.' );
+			}
+		}
+
 		/**
 		 * Unsets Captchas from the form.
 		 *


### PR DESCRIPTION
Cross-helper gap found by pre-merge review. WP Armour — Honeypot Anti Spam ships integrations for six form plugins; only the **Formidable** one had an unhook. Gravity Forms and Fluent Forms have the same failure mode, and **neither existing bypass reaches it.**

Both need an explicit unhook — but for genuinely different reasons, which is why this isn't a copy of the Formidable fix.

## Gravity Forms — the marker fallback can't cover it

WP Armour hooks `gform_validation` at priority 10 and, on a spam verdict, sets `is_valid = false` and attaches the failure to `$form['fields'][0]` with the `wpa_error_message` option (`wpa_gravityforms.php:6-17`).

`checkview_bypass_captcha_validation()` can't clear that:

- field `[0]` is whatever the form's first field happens to be, so `checkview_anti_bot_field_types` never matches;
- the default message — `" Spamming or your Javascript is disabled !!"` — contains **none** of the `checkview_anti_bot_validation_markers`.

Adding a marker wouldn't be a fix either: that message is a **site option the owner can rewrite to anything**, so marker matching is unreliable by construction. There's an assertion recording that.

## Fluent Forms — nothing but an unhook is possible

Stronger case. WP Armour's Fluent callback doesn't return a verdict at all — it calls `wp_send_json_error()` and `wp_die()` (`wpa_fluentform.php:6-14`), **terminating the request**. There is no return value for any filter to override.

It's also registered **outside** WP Armour's `! is_admin()` gate (`wp-armour.php:30`), unlike the GF and Formidable integrations — so it fires on admin-ajax, which is exactly where Fluent submits.

Both hook spellings are removed: WP Armour currently registers `fluentform/before_insert_submission` and leaves the legacy underscore form commented out, but Fluent renamed these at 4.3.22 and WP Armour has shipped both.

## Why this matters at all

`wpa_check_is_spam()` (`wpa_functions.php:136-153`) **fails closed** — a submission is spam *unless* it carries WP Armour's JS-injected fields. So the failure mode is a hard block, not a soft one.

## Implementation

Both registered on `init` at `PHP_INT_MAX`, because WP Armour includes its integrations from an `init` callback at the **default** priority (`wp-armour.php:17-32`) — the same priority these helpers load at, so ordering would otherwise depend on registration order.

Both degrade to a logged no-op: nothing removed and no such function means the plugin is absent; the function present but not removable means it moved priority or was renamed — worth surfacing rather than silently regressing.

## Verification

**15 executed assertions, 0 failures**, against an emulation of `add`/`remove`/`has_action` and reproducing WP Armour's own registrations:

- each callback removed
- **CheckView's own `gform_validation` bypass on the same hook is NOT removed**
- **Fluent's own callback on the same hook is NOT removed**
- both Fluent hook spellings cleared
- repeat runs report drift
- two assertions record *why* a marker fallback was rejected for GF and *why* nothing but an unhook can work for Fluent

Caught a harness bug on the way: my hook-id helper couldn't hash a closure, and the Fluent helper registers one on `fluentform/recaptcha_v3_ref_score`.

Not verified against a live WP Armour install.

## Deliberately not in this PR

- WP Armour also hooks `wpcf7_validate`, `wpforms_process_before` and `elementor_pro/forms/validation` — same family, three more helpers.
- CleanTalk reaches Formidable via `frm_entries_before_create` plus an ajax hook at priority 1, and the Formidable helper does **not** set `$cleantalk_executed` the way the GF and Forminator helpers do.

## Base

`development`. Touches only the GF and Fluent helpers, which no other open PR modifies — verified no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
