### PR TITLE
fix(cf7): complete the test after the mail, not before it

### DIFF
--- a/includes/formhelpers/class-checkview-cf7-helper.php
+++ b/includes/formhelpers/class-checkview-cf7-helper.php
@@ -33,6 +33,13 @@ if ( ! class_exists( 'Checkview_Cf7_Helper' ) ) {
 		 * @var Checkview_Loader $loader Maintains and registers all hooks for the plugin.
 		 */
 		public $loader;
+
+		/**
+		 * Test id held between the clone and the completion.
+		 *
+		 * @var string
+		 */
+		protected $pending_test_id = '';
 		/**
 		 * Constructor.
 		 *
@@ -60,6 +67,20 @@ if ( ! class_exists( 'Checkview_Cf7_Helper' ) ) {
 				),
 				99,
 				1
+			);
+
+			// Must not complete in `wpcf7_before_send_mail`: completion deletes
+			// `disable_email_receipt_<test_id>`, which checkview_inject_email()
+			// still needs to read from `wpcf7_mail_components` afterwards.
+			// `wpcf7_submit` also fires on mail_failed, so the test cannot hang.
+			add_action(
+				'wpcf7_submit',
+				array(
+					$this,
+					'checkview_cf7_complete_after_submit',
+				),
+				99,
+				2
 			);
 
 			add_action(
@@ -403,8 +424,27 @@ if ( ! class_exists( 'Checkview_Cf7_Helper' ) ) {
 					}
 				}
 
-				complete_checkview_test( $checkview_test_id );
+				// Deferred to `wpcf7_submit` — see the registration comment.
+				$this->pending_test_id = $checkview_test_id;
 			}
+		}
+
+		/**
+		 * Finishes the testing session once CF7 has attempted the mail.
+		 *
+		 * @param \WPCF7_ContactForm $contact_form Submitted form (unused).
+		 * @param array              $result       Submission result (unused).
+		 * @return void
+		 */
+		public function checkview_cf7_complete_after_submit( $contact_form = null, $result = array() ) {
+			if ( '' === $this->pending_test_id ) {
+				return;
+			}
+
+			$test_id                = $this->pending_test_id;
+			$this->pending_test_id  = '';
+
+			complete_checkview_test( $test_id );
 		}
 
 		/**


### PR DESCRIPTION
**CF7's keep-original-recipient mode is unreachable today.** Live bug, not latent — found while reviewing #197, but independent of it.

## The ordering

`checkview_inject_email()` chooses APPEND vs REPLACE by reading `disable_email_receipt_<test_id>`. `complete_checkview_test()` **deletes that option** — and the helper called it from `checkview_cf7_before_send_mail`, which runs first:

```
submission.php:111   $abort = ! $this->before_send_mail();   -> wpcf7_before_send_mail   (we completed here)
submission.php:123   } elseif ( $this->mail() ) {            -> wpcf7_mail_components    (we read the option here)
```

By the time the email filter ran the option was gone, so the condition always fell through to the `else`: **recipient replaced, Cc and Bcc stripped.** Every CF7 test behaved as though replace-mode had been requested, whatever the test actually asked for.

## The fix

Completion moves to **`wpcf7_submit`** (`contact-form.php:1089`) — fires once per submission after the entire flow (validation, `before_send_mail`, `mail`) and **regardless of whether the mail succeeded**.

I rejected `wpcf7_mail_sent` for exactly that reason: it only fires on success, so a `mail_failed` submission would never complete and would hang to timeout.

The clone stays where it was; only the completion moved. A pending-id property carries the test id between the two — cleared on use so a second `wpcf7_submit` can't complete twice, and empty when the submission never reached the clone (validation failure), in which case nothing completes.

## Verification

**13 executed assertions, 0 failures**, reproducing CF7's real sequence:

- keep-original requested → the customer's recipient is **preserved** *and* the test inbox appended
- replace-mode still replaces and still strips Cc/Bcc
- completion happens exactly once across two firings, and not at all without a pending id
- **one assertion replays the OLD order** and confirms keep-original was unreachable under it

Not verified against a live CF7 install.

## Why this matters for #197

#197 extends the same option-reading pattern to `allow_original_recipients`, so that feature would have been **dead on arrival for CF7** — the flag deleted before the filter could read it. Fixing the ordering here unblocks it rather than patching around it.

## Base

`development`. Touches only the CF7 helper, which no other open PR modifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
