### PR TITLE
fix(cf7,wpforms,elementor): unhook WP Armour, which their spam bypasses miss

### DIFF
--- a/includes/formhelpers/class-checkview-cf7-helper.php
+++ b/includes/formhelpers/class-checkview-cf7-helper.php
@@ -145,6 +145,41 @@ if ( ! class_exists( 'Checkview_Cf7_Helper' ) ) {
 				-PHP_INT_MAX,
 				0
 			);
+
+			// WP Armour is not covered by the spam bypasses above: it invalidates
+			// the submission itself rather than flagging it as spam, so
+			// `wpcf7_spam` and `wpcf7_skip_spam_check` never see it.
+			//
+			// On `init` at PHP_INT_MAX because WP Armour includes its
+			// integrations from an `init` callback at the default priority
+			// (wp-armour.php:17-24), the same priority this helper loads at.
+			add_action(
+				'init',
+				array( $this, 'checkview_unhook_wp_armour' ),
+				PHP_INT_MAX
+			);
+		}
+
+		/**
+		 * Removes WP Armour's Contact Form 7 validation callback for this request.
+		 *
+		 * Degrades to a logged no-op — nothing removed and no such function means
+		 * the plugin is absent; the function present but not removable means it
+		 * changed priority or was renamed, which is worth surfacing.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @return void
+		 */
+		public function checkview_unhook_wp_armour() {
+			if ( remove_filter( 'wpcf7_validate', 'wpa_contactform7_extra_validation', 10 ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Unhooked WP Armour from wpcf7_validate for this CheckView test.' );
+				return;
+			}
+
+			if ( function_exists( 'wpa_contactform7_extra_validation' ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'WP Armour detected but its wpcf7_validate callback was not removable (priority changed or renamed?) — CF7 submissions may still be rejected as spam.' );
+			}
 		}
 
 		/**

--- a/includes/formhelpers/class-checkview-elementor-helper.php
+++ b/includes/formhelpers/class-checkview-elementor-helper.php
@@ -110,6 +110,40 @@ if ( ! class_exists( 'Checkview_Elementor_Helper' ) ) {
 				'hcap_activate',
 				'__return_false'
 			);
+
+			// WP Armour calls add_error() on the record rather than flagging the
+			// submission as spam, so the bypasses above never see it.
+			//
+			// On `init` at PHP_INT_MAX because WP Armour includes its
+			// integrations from an `init` callback at the default priority
+			// (wp-armour.php:17-24), the same priority this helper loads at.
+			add_action(
+				'init',
+				array( $this, 'checkview_unhook_wp_armour' ),
+				PHP_INT_MAX
+			);
+		}
+
+		/**
+		 * Removes WP Armour's Elementor Pro forms validation callback.
+		 *
+		 * Degrades to a logged no-op — nothing removed and no such function means
+		 * the plugin is absent; the function present but not removable means it
+		 * changed priority or was renamed, which is worth surfacing.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @return void
+		 */
+		public function checkview_unhook_wp_armour() {
+			if ( remove_action( 'elementor_pro/forms/validation', 'wpa_elementor_extra_validation', 10 ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Unhooked WP Armour from elementor_pro/forms/validation for this CheckView test.' );
+				return;
+			}
+
+			if ( function_exists( 'wpa_elementor_extra_validation' ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'WP Armour detected but its elementor_pro/forms/validation callback was not removable (priority changed or renamed?) — Elementor submissions may still be rejected as spam.' );
+			}
 		}
 
 		/**

--- a/includes/formhelpers/class-checkview-wpforms-helper.php
+++ b/includes/formhelpers/class-checkview-wpforms-helper.php
@@ -154,6 +154,40 @@ if ( ! class_exists( 'Checkview_Wpforms_Helper' ) ) {
 				1,
 				3
 			);
+
+			// WP Armour adds its own validation error rather than flagging the
+			// submission as spam, so the captcha/spam bypasses above never see it.
+			//
+			// On `init` at PHP_INT_MAX because WP Armour includes its
+			// integrations from an `init` callback at the default priority
+			// (wp-armour.php:17-24), the same priority this helper loads at.
+			add_action(
+				'init',
+				array( $this, 'checkview_unhook_wp_armour' ),
+				PHP_INT_MAX
+			);
+		}
+
+		/**
+		 * Removes WP Armour's WPForms validation callback for this request.
+		 *
+		 * Degrades to a logged no-op — nothing removed and no such function means
+		 * the plugin is absent; the function present but not removable means it
+		 * changed priority or was renamed, which is worth surfacing.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @return void
+		 */
+		public function checkview_unhook_wp_armour() {
+			if ( remove_filter( 'wpforms_process_before', 'wpa_wpforms_extra_validation', 10 ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'Unhooked WP Armour from wpforms_process_before for this CheckView test.' );
+				return;
+			}
+
+			if ( function_exists( 'wpa_wpforms_extra_validation' ) ) {
+				Checkview_Admin_Logs::add( 'ip-logs', 'WP Armour detected but its wpforms_process_before callback was not removable (priority changed or renamed?) — WPForms submissions may still be rejected as spam.' );
+			}
 		}
 
 		/**


### PR DESCRIPTION
Extends #240 to the three remaining helpers WP Armour integrates with. Same
defect in each: WP Armour does not flag a submission as spam, it invalidates the
submission directly, so none of the captcha/spam bypasses in these helpers can
see or override it.

  wpcf7_validate                    wpa_contactform7_extra_validation  prio 10
  wpforms_process_before            wpa_wpforms_extra_validation       prio 10
  elementor_pro/forms/validation    wpa_elementor_extra_validation     prio 10

(honeypot/includes/integration/wpa_{contactform7,wpforms,elementor}.php)

For CF7 specifically, `wpcf7_spam` and `wpcf7_skip_spam_check` are both already
bypassed and neither helps: WP Armour calls $result->invalidate() from
wpcf7_validate, which is a different code path entirely.

Registered on `init` at PHP_INT_MAX, matching #240 — WP Armour includes its
integration files from an `init` callback at the default priority
(wp-armour.php:17-24), the same priority these helpers load at.

Each degrades to a logged no-op: nothing removed and no such function means the
plugin is absent; the function present but not removable means the priority
changed or it was renamed, which is logged as still-at-risk rather than passing
silently.

Verified with a harness that reads BOTH sides from the shipped files — WP
Armour's own registration and the helper's removal — so a priority or name
change on either side fails the correspondence assertions instead of degrading
to a silent no-op. 39 assertions, 0 failed.