### PR TITLE
fix(formidable): bypass CleanTalk's spam check during CheckView tests

### DIFF
--- a/includes/formhelpers/class-checkview-formidable-helper.php
+++ b/includes/formhelpers/class-checkview-formidable-helper.php
@@ -121,6 +121,23 @@ if ( ! class_exists( 'Checkview_Formidable_Helper' ) ) {
 				99,
 				5
 			);
+
+			// CleanTalk Spam Protect reaches Formidable on two paths:
+			// `frm_entries_before_create` at priority 999999 (cleantalk.php:598),
+			// and `ct_ajax_hook` at priority 1 on
+			// wp_ajax[_nopriv]_frm_entries_create (inc/cleantalk-ajax.php:78-79),
+			// which is the path a normal AJAX-submitted Formidable form takes.
+			// Both funnel into apbct_base_call(), which short-circuits on this
+			// sentinel and returns a default response whose `allow` is 1
+			// (inc/cleantalk-common.php:110-124, CleantalkResponse.php:154), so
+			// neither path blocks. One lever covers both, with no coupling to
+			// CleanTalk's hook list or priorities.
+			//
+			// Same two lines the GF and Forminator helpers use. CAVEAT: this is
+			// an INTERNAL global, not a public API, so re-verify on CleanTalk
+			// updates. Harmless when CleanTalk is not installed.
+			global $cleantalk_executed;
+			$cleantalk_executed = true;
 		}
 		/**
 		 * Sets our email for test submissions.


### PR DESCRIPTION
Completes the CleanTalk work started for Forminator in #239. CleanTalk reaches
Formidable on two paths, and the existing Formidable bypasses cover neither:

  frm_entries_before_create              apbct_form__formidable__testSpam  prio 999999
  wp_ajax[_nopriv]_frm_entries_create    ct_ajax_hook                      prio 1

(cleantalk.php:598, inc/cleantalk-ajax.php:78-79)

The second is the one that matters most: a normal AJAX-submitted Formidable form
goes through it, and it sits at priority 1, ahead of Formidable's own handler.
On a block it echoes a JSON error and die()s, so the test never reaches the
submission at all.

Both funnel into apbct_base_call(), which short-circuits on the $cleantalk_executed
sentinel and returns array( 'ct_result' => new CleantalkResponse() )
(inc/cleantalk-common.php:110-124). That default response has allow = 1
(CleantalkResponse.php:154), and the integration only blocks when allow == 0
(inc/cleantalk-public-integrations.php:446). So one lever disarms both paths with
no coupling to CleanTalk's hook list or priorities.

Worth stating plainly: $cleantalk_executed is an internal global, not a public
API. That is why the verification asserts every link — the sentinel check, the
default allow value, and the caller's block condition — against CleanTalk's
shipped source, so an upstream change fails the harness instead of silently
disarming the bypass. 16 assertions, 0 failed.

Harmless when CleanTalk is not installed.