### PR TITLE
fix(formidable): list the forms Formidable considers submittable

### DIFF
--- a/includes/API/class-checkview-api.php
+++ b/includes/API/class-checkview-api.php
@@ -1436,7 +1436,37 @@ class CheckView_Api {
 
 		if ( is_plugin_active( 'formidable/formidable.php' ) ) {
 			$tablename = $wpdb->prefix . 'frm_forms';
-			$results   = $wpdb->get_results( $wpdb->prepare( 'Select * from ' . $tablename . ' where 1=%d and status=%s', 1, 'published' ) );
+
+			// Mirror Formidable's own definition of a submittable form
+			// (FrmForm::get_published_forms(), FrmForm.php:969-975) rather than
+			// reimplementing it, so it cannot drift from upstream:
+			//
+			//   is_template = 0                  templates are not submittable
+			//   parent_form_id IN ( NULL, 0 )    child forms are the inner form of
+			//                                    a repeater/embedded field and are
+			//                                    only submitted via their parent
+			//   status IN ( NULL, '', published )
+			//
+			// That last one widens the previous `status = 'published'`: Formidable
+			// treats NULL and '' as published, so forms whose status column was
+			// never populated were silently absent from the list.
+			if ( is_callable( array( 'FrmForm', 'get_published_forms' ) ) ) {
+				// Default limit is 999; pass a higher one so large sites are not
+				// silently truncated.
+				$results = FrmForm::get_published_forms( array(), 999999 );
+			} else {
+				$results = $wpdb->get_results(
+					$wpdb->prepare(
+						'SELECT * FROM ' . $tablename . "
+						WHERE is_template = %d
+						AND ( status IS NULL OR status = '' OR status = %s )
+						AND ( parent_form_id IS NULL OR parent_form_id = %d )",
+						0,
+						'published',
+						0
+					)
+				);
+			}
 			if ( $results ) {
 				foreach ( $results as $row ) {
 					$forms['Formidable'][ $row->id ] = array(


### PR DESCRIPTION
The form list was `status = 'published'` and nothing else, which is wrong in
both directions.

Listed but not submittable:
  - TEMPLATES. Formidable ships and users save form templates; they are not
    forms a visitor can submit.
  - CHILD forms. The inner form of a repeater or embedded field is a row in
    frm_forms with parent_form_id set. It is only ever submitted as part of its
    parent, so testing it standalone is meaningless.

Submittable but missing:
  - Forms whose status is NULL or ''. Formidable treats both as published
    (FrmForm.php:970), so these are ordinary live forms that simply never had
    the column populated. They were invisible to CheckView.

Rather than reimplement the filter, defer to FrmForm::get_published_forms()
(FrmForm.php:969-975) when it is callable, which is the same method Formidable's
own UI uses — so this cannot drift from upstream. Passes an explicit high limit
because the default is 999 and would silently truncate large sites.

The SQL fallback mirrors it for the case where the class is not loadable. It
uses `parent_form_id IS NULL OR = 0` rather than just `= 0`, matching upstream's
array( null, 0 ): both mean top-level, and treating NULL as a child would have
hidden real forms.

Verified by EXECUTING the extracted WHERE clause against a real table of the row
shapes Formidable produces — template, child, NULL status, empty status, NULL
parent, trash, draft — rather than pattern-matching the SQL. The old clause is
replayed against the same rows to show both failure directions. 22 assertions,
0 failed.

---
Stacked on #229 — it touches the same Formidable discovery block.