### PR TITLE
fix(cf7): discover forms placed with the legacy [contact-form] shortcode

### DIFF
--- a/includes/API/class-checkview-api.php
+++ b/includes/API/class-checkview-api.php
@@ -1587,6 +1587,26 @@ class CheckView_Api {
 						);
 					}
 
+					// CF7 still registers `[contact-form]` alongside
+					// `[contact-form-7]` (load.php:136-137), for content written
+					// before CF7 3.0. It does NOT take the same id: the legacy
+					// branch reads the first positional attribute and resolves it
+					// through the `_old_cf7_unit_id` post meta
+					// (contact-form-functions.php:258-264, :24-39), so the number
+					// in `[contact-form 1]` is an old unit id, unrelated to the
+					// post ID or the hash. Matching post IDs here would attribute
+					// other forms' pages to this one.
+					//
+					// Only forms migrated from pre-3.0 CF7 carry that meta, so on
+					// a modern install this adds no patterns at all.
+					$old_unit_id = get_post_meta( $row->ID, '_old_cf7_unit_id', true );
+					if ( '' !== $old_unit_id && is_numeric( $old_unit_id ) ) {
+						$old_unit_id = absint( $old_unit_id );
+						// Bounded, or form 1 also matches `[contact-form 12]`.
+						$cf7_patterns[] = '%[contact-form ' . $old_unit_id . ']%';
+						$cf7_patterns[] = '%[contact-form ' . $old_unit_id . ' %';
+					}
+
 					// Placeholder list is generated from the pattern count, not
 					// from any user-supplied value, so the interpolation below is
 					// a fixed repetition of `post_content LIKE %s`. Every actual


### PR DESCRIPTION
CF7 still registers `[contact-form]` alongside `[contact-form-7]`, both to the
same callback (load.php:136-137), for content written before CF7 3.0. Pages
using it were invisible to discovery.

The important part is that it does NOT take the same id, and matching post IDs
there would have been a wrong-attribution bug rather than a fix. The legacy
branch reads the first POSITIONAL attribute and resolves it through the
`_old_cf7_unit_id` post meta (contact-form-functions.php:258-264 -> :24-39), so
the 1 in `[contact-form 1]` is an old unit id with no relationship to the post ID
or the hash. Two different forms can hold those two numbers.

So the patterns are built from that meta, and only when it exists and is numeric.
Only forms migrated from pre-3.0 CF7 carry it, so on a modern install this adds
no patterns at all and cannot change existing results.

Both patterns are terminated (`]` or a space before further attributes) for the
same reason as #232: unterminated, old id 1 would match `[contact-form 12]` and
inherit that form's pages.

Verified by evaluating the shipped pattern templates under real SQL LIKE
semantics against content CF7 produces, including the negative cases — 12, 123,
10, and the modern `[contact-form-7 id=...]` forms — plus a case proving the
unterminated variant would have mismatched. 19 assertions, 0 failed.

---
Stacked on #233 (which is itself stacked on #231) — same CF7 pattern block.