### PR TITLE
fix(gravityforms): discover plural-tag and single-quoted form embeds

### DIFF
--- a/includes/API/class-checkview-api.php
+++ b/includes/API/class-checkview-api.php
@@ -1246,33 +1246,50 @@ class CheckView_Api {
 					foreach ( $addons as $addon ) {
 						$forms['GravityForms'][ $row->id ]['addons'][] = $addon->addon_slug;
 					}
+					// Gravity Forms registers BOTH `[gravityform]` and
+					// `[gravityforms]` to the same callback
+					// (gravityforms.php:252-253). The plural is the original
+					// spelling, so it is precisely the older content that carries
+					// it. The two tags do not overlap as LIKE patterns — after
+					// `[gravityform` the singular needs a space and the plural an
+					// `s` — so each spelling needs its own set.
+					//
+					// Each spelling gets three bounded ID forms. The unquoted one
+					// was unterminated, so form 12 also matched
+					// [gravityform id=123] and silently inherited its pages: `]`
+					// ends the shortcode, a space means further attributes follow
+					// (title, description, ajax, tabindex, field_values, theme).
+					// Quoted variants are bounded by their closing quote.
+					//
+					// Single quotes are included because WordPress's own
+					// shortcode parser accepts `id="7"`, `id='7'` and `id=7`
+					// identically (wp-includes/shortcodes.php:551), so a
+					// single-quoted embed is a working form that was undiscovered.
+					$gf_patterns = array(
+						'%wp:gravityforms/form {"formId":"' . $row->id . '"%',
+					);
+					foreach ( array( 'gravityform', 'gravityforms' ) as $gf_tag ) {
+						$gf_patterns[] = '%[' . $gf_tag . ' id="' . $row->id . '"%';
+						$gf_patterns[] = "%[" . $gf_tag . " id='" . $row->id . "'%";
+						$gf_patterns[] = '%[' . $gf_tag . ' id=' . $row->id . ']%';
+						$gf_patterns[] = '%[' . $gf_tag . ' id=' . $row->id . ' %';
+					}
+
+					// Placeholder list is generated from the pattern count, not
+					// from any user-supplied value, so the interpolation below is
+					// a fixed repetition of `post_content LIKE %s`. Every actual
+					// value is still bound through $wpdb->prepare().
 					// WPDBPREPARE.
+					$gf_where = implode( ' OR ', array_fill( 0, count( $gf_patterns ), 'post_content LIKE %s' ) );
+
 					$form_pages = $wpdb->get_results(
 						$wpdb->prepare(
 							"SELECT ID, post_type FROM {$wpdb->prefix}posts
-						WHERE 1=1 
-						AND (
-							post_content LIKE %s 
-							OR post_content LIKE %s 
-							OR post_content LIKE %s  
-							OR post_content LIKE %s
-						) 
-						AND post_status = 'publish' 
+						WHERE 1=1
+						AND ( {$gf_where} )
+						AND post_status = 'publish'
 						AND post_type NOT IN ('kadence_wootemplate', 'kadence_element', 'revision')",
-							'%wp:gravityforms/form {"formId":"' . $row->id . '"%',
-							// The unquoted shortcode pattern was unterminated, so
-							// form 12 also matched [gravityform id=123] and
-							// silently inherited that form's pages. The two slots
-							// below previously held byte-identical duplicates, so
-							// both terminators fit without changing the
-							// placeholder count: `]` ends the shortcode, a space
-							// means further attributes follow (title, description,
-							// ajax, tabindex, field_values, theme). Either way the
-							// ID is bounded. The quoted variant above is already
-							// bounded by its closing quote.
-							'%[gravityform id="' . $row->id . '"%',
-							'%[gravityform id=' . $row->id . ']%',
-							'%[gravityform id=' . $row->id . ' %'
+							$gf_patterns
 						)
 					);
 					if ( $form_pages ) {


### PR DESCRIPTION
Two working ways to embed a Gravity Form were undiscoverable.

1. The plural tag. Gravity Forms registers BOTH `[gravityform]` and
   `[gravityforms]` to the same callback (gravityforms.php:252-253). The plural
   is the ORIGINAL spelling — the singular came later — so it is exactly the
   older, long-standing content that carries it. GF's own docs only mention the
   singular, which is why it was missed.

2. Single-quoted ids. WordPress's shortcode parser accepts `id="7"`, `id='7'`
   and `id=7` identically (wp-includes/shortcodes.php:551), but only the double
   and unquoted forms were matched.

Restructures the block to build the pattern list rather than hardcode four
placeholders, mirroring the CF7 block: 1 block pattern + 4 bounded ID forms per
spelling = 9. The two spellings cannot overlap as LIKE patterns — after
`[gravityform` the singular requires a space and the plural an `s` — so each
needs its own set rather than a shared prefix.

Bounding from #232 is preserved on every new unquoted pattern: `]` ends the
shortcode, a space means further attributes follow. Without it, form 7 would
match [gravityform id=77].

Verified by extracting the pattern-building block from the shipped file and
EXECUTING it, so the assertions run against the real construction — 9 patterns,
no duplicates, placeholder count equal to pattern count, every working embed
found, and 77/7123/70 correctly excluded. WordPress's own parser is executed to
confirm single-quoted ids really do resolve. 26 assertions, 0 failed.

---
Stacked on #232 — same GF pattern block.