### PR TITLE
test(harness): commit the standalone verification cases

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -42,3 +42,5 @@ package.xml
 phpunit.xml*
 .phpunit.result.cache
 *.bak
+
+tests/harness/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ CLAUDE.md
 *-har.json
 *.phar
 .phpunit.result.cache
+
+# Verification harness fixtures (downloaded, see tests/harness/fetch-fixtures.sh)
+tests/harness/fixtures/

--- a/tests/harness/README.md
+++ b/tests/harness/README.md
@@ -1,0 +1,84 @@
+# Verification harness
+
+Standalone assertion scripts that drive the plugin's real methods and check them
+against the real source of the plugins we integrate with.
+
+```bash
+tests/harness/fetch-fixtures.sh          # once, plus --wordpress for two cases
+php tests/harness/run.php                # all cases
+php tests/harness/run.php formidable     # only matching cases
+```
+
+Exit code is 1 if any assertion fails.
+
+## Why this exists alongside `tests/`
+
+The PHPUnit suite in `tests/` cannot bootstrap from an ordinary checkout — it
+needs a provisioned WordPress test install. That made every fix in this plugin
+unverifiable by anyone who just cloned the repo, so the checks that actually
+caught the bugs lived in a scratch directory and were lost between sessions.
+
+These cases need nothing but `php`. They stub the handful of WordPress functions
+each one touches, then call the plugin's real methods.
+
+## What the cases are for
+
+Most of them are not testing our logic in isolation. They are pinning **our
+assumptions about other people's code** — the assumptions that turned out to be
+wrong nearly every time a bug was found here:
+
+- a hook name built by string concatenation, so grepping the literal finds nothing
+- a callback registered at a priority `remove_action()` must match exactly
+- a default value one call deeper than the file being read
+- a shortcode tag with an undocumented alias
+- an upstream `WHERE` clause we had reimplemented slightly differently
+
+So the cases read the shipped third-party source and assert the correspondence.
+If WP Armour moves a priority, or CleanTalk changes what its sentinel returns, or
+Formidable redefines "published", the relevant case fails — rather than the bypass
+silently becoming a no-op and a test run going quietly wrong.
+
+Where a case can execute rather than pattern-match, it does: `formidable_form_list`
+runs the extracted `WHERE` clause against a real SQLite table of the row shapes
+Formidable produces, and `gf_plural_quoted` runs WordPress's own shortcode parser.
+
+## Fixtures are deliberately not committed
+
+`fetch-fixtures.sh` downloads current stable builds from wordpress.org into
+`tests/harness/fixtures/`, which is git-ignored. Pinning copies in the repo would
+defeat the purpose — several cases exist precisely to notice when one of these
+plugins changes, so they have to read whatever is current.
+
+Gravity Forms is not fetchable (commercial), so the GF cases assert against
+WordPress core's shortcode parser and our own source instead.
+
+## Skips are not passes
+
+A case skips, rather than fails, when:
+
+- a fixture is missing — run `fetch-fixtures.sh`
+- the change it covers is not in the tree yet — it names the PR
+
+The second is what makes this useful during the current backlog: on `development`
+every case skips and reports which PR it is waiting for. As each merges, its case
+starts running on its own. Run it after each merge.
+
+`run.php` always lists skips separately from passes and never counts a skip as
+green, so a run that verified nothing cannot look like a run that verified
+everything.
+
+## Adding a case
+
+Drop a file in `cases/`. It should:
+
+1. `require_once __DIR__ . '/../bootstrap.php';`
+2. declare what it needs — `cv_need_fixture()`, `cv_need_wordpress()`,
+   `cv_need_change()`
+3. assert with `cv_ok()`
+4. end with `cv_finish()`
+
+Each case runs in its own process, so it can freely declare `add_action()`,
+`Checkview_Admin_Logs` and similar without colliding with any other case.
+
+Prefer extracting the thing under test from the shipped file over restating it —
+a copied constant drifts, an extracted one cannot.

--- a/tests/harness/bootstrap.php
+++ b/tests/harness/bootstrap.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Shared bootstrap for the standalone verification harness.
+ *
+ * Every case file is executed in its OWN php process by run.php, so each is free
+ * to declare `add_action()`, `Checkview_Admin_Logs` and friends without
+ * colliding with any other case. Nothing here emulates WordPress; each case
+ * stubs exactly what it needs.
+ *
+ * @package Checkview
+ * @subpackage Checkview/tests/harness
+ */
+
+/** Plugin root, derived rather than hardcoded so the harness is portable. */
+define( 'CV_PLUGIN_DIR', dirname( __DIR__, 2 ) );
+
+/** Third-party plugin sources. Not committed — see fetch-fixtures.sh. */
+define( 'CV_FIXTURES', __DIR__ . '/fixtures' );
+
+/** A WordPress checkout, for the few cases that assert against core itself. */
+define( 'CV_WP', CV_PLUGIN_DIR . '/wordpress' );
+
+/** Exit code run.php reads as "skipped", distinct from pass (0) and fail (1). */
+define( 'CV_EXIT_SKIP', 2 );
+
+$GLOBALS['cv_asserts'] = 0;
+$GLOBALS['cv_fails']   = 0;
+
+/**
+ * Records one assertion.
+ *
+ * @param bool   $condition Result under test.
+ * @param string $label     What is being asserted.
+ * @return void
+ */
+function cv_ok( bool $condition, string $label ): void {
+	++$GLOBALS['cv_asserts'];
+	if ( ! $condition ) {
+		++$GLOBALS['cv_fails'];
+		echo "  FAIL: {$label}\n";
+		return;
+	}
+	echo "  ok:   {$label}\n";
+}
+
+/**
+ * Ends the case without running it, reporting why.
+ *
+ * A skip is not a pass. run.php counts skips separately and names them, so an
+ * absent fixture or an unmerged branch can never be mistaken for green.
+ *
+ * @param string $reason Why this case cannot run here.
+ * @return void
+ */
+function cv_skip( string $reason ): void {
+	echo "SKIP: {$reason}\n";
+	exit( CV_EXIT_SKIP );
+}
+
+/**
+ * Requires a third-party plugin fixture, skipping the case when it is absent.
+ *
+ * @param string $slug Fixture directory name, e.g. 'forminator'.
+ * @return string Absolute path to the fixture.
+ */
+function cv_need_fixture( string $slug ): string {
+	$path = CV_FIXTURES . '/' . $slug;
+	if ( ! is_dir( $path ) ) {
+		cv_skip( "fixture '{$slug}' not present — run tests/harness/fetch-fixtures.sh" );
+	}
+	return $path;
+}
+
+/**
+ * Requires a WordPress checkout, skipping the case when it is absent.
+ *
+ * @return string Absolute path to the WordPress root.
+ */
+function cv_need_wordpress(): string {
+	if ( ! is_file( CV_WP . '/wp-includes/shortcodes.php' ) ) {
+		cv_skip( 'no WordPress checkout at ./wordpress — run tests/harness/fetch-fixtures.sh' );
+	}
+	return CV_WP;
+}
+
+/**
+ * Requires a plugin file, skipping when it is absent.
+ *
+ * @param string $relative Path relative to the plugin root.
+ * @return string Absolute path.
+ */
+function cv_plugin_file( string $relative ): string {
+	$path = CV_PLUGIN_DIR . '/' . ltrim( $relative, '/' );
+	if ( ! is_file( $path ) ) {
+		cv_skip( "plugin file missing: {$relative}" );
+	}
+	return $path;
+}
+
+/**
+ * Requires that the change under test is actually present in the tree.
+ *
+ * These cases were written against branches that are not all merged. Running one
+ * against a tree that predates its fix would report a failure that is really
+ * just "not merged yet", so the case skips instead and names the PR.
+ *
+ * @param string $relative Plugin file to look in.
+ * @param string $needle   Literal that only exists once the change has landed.
+ * @param string $pr       Which PR introduces it, for the skip message.
+ * @return string The file's contents, since the caller almost always wants them.
+ */
+function cv_need_change( string $relative, string $needle, string $pr ): string {
+	$src = (string) file_get_contents( cv_plugin_file( $relative ) );
+	if ( false === strpos( $src, $needle ) ) {
+		cv_skip( "{$pr} is not in this tree yet ({$relative} has no '{$needle}')" );
+	}
+	return $src;
+}
+
+/**
+ * Emulates SQL LIKE. `%` matches any run, `_` a single character.
+ *
+ * Used by the discovery cases, which assert against the same patterns the API
+ * hands to `$wpdb->prepare()`.
+ *
+ * @param string $pattern LIKE pattern.
+ * @param string $subject Text to match.
+ * @return bool
+ */
+function cv_like( string $pattern, string $subject ): bool {
+	$regex  = '';
+	$length = strlen( $pattern );
+	for ( $i = 0; $i < $length; $i++ ) {
+		$char = $pattern[ $i ];
+		if ( '%' === $char ) {
+			$regex .= '.*';
+		} elseif ( '_' === $char ) {
+			$regex .= '.';
+		} else {
+			$regex .= preg_quote( $char, '#' );
+		}
+	}
+	return (bool) preg_match( '#^' . $regex . '$#s', $subject );
+}
+
+/**
+ * Prints the tally run.php parses, and exits with the right code.
+ *
+ * @return void
+ */
+function cv_finish(): void {
+	echo "\n{$GLOBALS['cv_asserts']} assertions, {$GLOBALS['cv_fails']} failed\n";
+	exit( $GLOBALS['cv_fails'] > 0 ? 1 : 0 );
+}

--- a/tests/harness/cases/append_mode_scoping.php
+++ b/tests/harness/cases/append_mode_scoping.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Verification that append-mode's flag is scoped per test id.
+ *
+ * The flag decides whether a customer's REAL recipients receive test email, so
+ * two concurrent tests must not be able to read each other's setting.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+cv_need_change( 'includes/checkview-functions.php', 'cv_should_allow_original_recipients', 'PR #197' );
+
+$GLOBALS['cv_opts']    = array();
+$GLOBALS['cv_test_id'] = '';
+
+function get_option( $k, $d = false ) { return $GLOBALS['cv_opts'][ $k ] ?? $d; }
+function cv_update_option( $k, $v, $autoload = false ) { $GLOBALS['cv_opts'][ $k ] = $v; }
+function cv_delete_option( $k ) { unset( $GLOBALS['cv_opts'][ $k ] ); }
+function delete_option( $k ) { unset( $GLOBALS['cv_opts'][ $k ] ); }
+function get_checkview_test_id() { return $GLOBALS['cv_test_id']; }
+
+// Pull the real reader out of the shipped file so this cannot drift.
+$src = file_get_contents( CV_PLUGIN_DIR . '/includes/checkview-functions.php' );
+preg_match( '/\tfunction cv_should_allow_original_recipients\(\) \{.*?\n\t\}/s', $src, $m );
+if ( empty( $m[0] ) ) {
+	fwrite( STDERR, "could not extract cv_should_allow_original_recipients()\n" );
+	exit( 1 );
+}
+eval( $m[0] );
+
+
+/** What admin/class-checkview-admin.php now writes at test-init. */
+function init_test( string $test_id, bool $append ) {
+	if ( $append ) {
+		cv_update_option( 'allow_original_recipients_' . $test_id, 'true', true );
+		cv_update_option( 'allow_original_recipients_set_at_' . $test_id, (string) time(), true );
+	}
+}
+
+echo "\n=== the flag is read per test id ===\n";
+$GLOBALS['cv_opts'] = array();
+init_test( 'test-A', true );
+
+$GLOBALS['cv_test_id'] = 'test-A';
+cv_ok( true === cv_should_allow_original_recipients(), 'test A, which asked for append-mode, gets it' );
+
+$GLOBALS['cv_test_id'] = 'test-B';
+cv_ok( false === cv_should_allow_original_recipients(), "test B does NOT inherit test A's append-mode" );
+
+echo "\n=== concurrent tests do not interfere ===\n";
+$GLOBALS['cv_opts'] = array();
+init_test( 'test-A', true );
+init_test( 'test-B', false );   // B did not ask for it
+
+$GLOBALS['cv_test_id'] = 'test-A';
+cv_ok( true === cv_should_allow_original_recipients(), 'A still append after B started' );
+$GLOBALS['cv_test_id'] = 'test-B';
+cv_ok( false === cv_should_allow_original_recipients(), 'B still replace-mode' );
+
+echo "\n=== completing one test does not disarm the other ===\n";
+// What complete_checkview_test() now deletes.
+cv_delete_option( 'allow_original_recipients_test-B' );
+cv_delete_option( 'allow_original_recipients_set_at_test-B' );
+$GLOBALS['cv_test_id'] = 'test-A';
+cv_ok( true === cv_should_allow_original_recipients(), "completing B leaves A's flag intact" );
+
+cv_delete_option( 'allow_original_recipients_test-A' );
+cv_delete_option( 'allow_original_recipients_set_at_test-A' );
+cv_ok( false === cv_should_allow_original_recipients(), 'completing A clears it' );
+
+echo "\n=== fails closed ===\n";
+$GLOBALS['cv_opts'] = array();
+init_test( 'test-A', true );
+$GLOBALS['cv_test_id'] = '';
+cv_ok( false === cv_should_allow_original_recipients(), 'no resolvable test id -> replace-mode, not append' );
+
+$GLOBALS['cv_test_id'] = 'test-A';
+$GLOBALS['cv_opts']['allow_original_recipients_set_at_test-A'] = (string) ( time() - 3000 );  // > 45 min
+cv_ok( false === cv_should_allow_original_recipients(), 'stale timestamp still rejected (watchdog intact)' );
+
+$GLOBALS['cv_opts']['allow_original_recipients_set_at_test-A'] = (string) ( time() + 600 );   // future
+cv_ok( false === cv_should_allow_original_recipients(), 'future timestamp still rejected' );
+
+unset( $GLOBALS['cv_opts']['allow_original_recipients_set_at_test-A'] );
+cv_ok( false === cv_should_allow_original_recipients(), 'flag without a timestamp rejected' );
+
+echo "\n=== the OLD site-scoped shape is what allowed the leak ===\n";
+$GLOBALS['cv_opts'] = array(
+	'allow_original_recipients'         => 'true',
+	'allow_original_recipients_set_at'  => (string) time(),
+);
+$GLOBALS['cv_test_id'] = 'test-B';
+cv_ok( false === cv_should_allow_original_recipients(), 'an unscoped leftover no longer enables append for anyone' );
+
+echo "\n=== completion really deletes the scoped keys (read from the shipped file) ===\n";
+// The cases above hand-code what completion deletes, which would still pass if
+// someone removed the deletes. Assert against the real function body instead.
+preg_match( '/\tfunction complete_checkview_test\(.*?\n\t\}/s', $src, $cm );
+cv_ok( ! empty( $cm[0] ), 'extracted complete_checkview_test() from the shipped file' );
+$body = $cm[0] ?? '';
+cv_ok(
+	false !== strpos( $body, "cv_delete_option( 'allow_original_recipients_' . \$checkview_test_id )" ),
+	'completion deletes the per-test flag'
+);
+cv_ok(
+	false !== strpos( $body, "cv_delete_option( 'allow_original_recipients_set_at_' . \$checkview_test_id )" ),
+	'completion deletes the per-test timestamp'
+);
+cv_ok(
+	false !== strpos( $body, "cv_delete_option( 'allow_original_recipients' )" ),
+	'completion still clears the legacy unscoped flag'
+);
+// A stale flag outliving its test is the leak this whole PR is about.
+$scoped_deletes = preg_match_all( '/allow_original_recipients(?:_set_at)?_\' \. \$checkview_test_id/', $body );
+cv_ok( 2 === $scoped_deletes, 'both scoped keys deleted, no more and no fewer (got ' . $scoped_deletes . ')' );
+
+echo "\n=== the writes match the sibling per-test options (read from the shipped file) ===\n";
+$admin = file_get_contents( CV_PLUGIN_DIR . '/admin/class-checkview-admin.php' );
+
+// Orphaned keys are never cleaned up (a timed-out test never completes), so an
+// autoloaded key pair per test grows wp_options autoload without bound.
+preg_match_all(
+	"/cv_update_option\(\s*'allow_original_recipients(?:_set_at)?_'\s*\.\s*\\\$cv_test_id\s*,[^,]+,\s*(true|false)\s*\)/",
+	$admin,
+	$am
+);
+cv_ok( 2 === count( $am[1] ), 'both append-mode keys are written at test-init (found ' . count( $am[1] ) . ')' );
+cv_ok(
+	array( 'false', 'false' ) === $am[1],
+	'neither is autoloaded, matching disable_actions_<id> et al (got ' . implode( ', ', $am[1] ) . ')'
+);
+
+// Pin the sibling convention this is matching, so the comparison stays honest.
+preg_match_all(
+	"/cv_update_option\(\s*'(?:disable_actions|disable_email_receipt|disable_webhooks)_'\s*\.\s*\\\$cv_test_id\s*,[^,]+,\s*(true|false)\s*\)/",
+	$admin,
+	$sm
+);
+cv_ok( 3 === count( $sm[1] ), 'found the three sibling per-test writes (got ' . count( $sm[1] ) . ')' );
+cv_ok(
+	array( 'false', 'false', 'false' ) === $sm[1],
+	'siblings are still non-autoloaded, so the convention above is the real one'
+);
+
+// The flag is only honoured inside a signed request: checkview_init_current_test
+// is registered solely under is_bot().
+$core = file_get_contents( CV_PLUGIN_DIR . '/includes/class-checkview.php' );
+cv_ok(
+	(bool) preg_match( "/if \(\s*self::is_bot\(\)\s*\)\s*\{(?:(?!\}).)*?'checkview_init_current_test'/s", $core ),
+	'test-init (which reads $_REQUEST[allow_original_recipients]) stays behind is_bot()'
+);
+
+cv_finish();

--- a/tests/harness/cases/cf7_complete_ordering.php
+++ b/tests/harness/cases/cf7_complete_ordering.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Verification for the CF7 completion-ordering fix.
+ *
+ * Reproduces CF7's real submit sequence — before_send_mail() then mail() —
+ * and checks that the per-test option survives long enough for the email
+ * filter to read it.
+ *
+ *   submission.php:111  $abort = ! $this->before_send_mail();   -> wpcf7_before_send_mail
+ *   submission.php:123  } elseif ( $this->mail() ) {            -> wpcf7_mail_components (mail.php:239)
+ *   contact-form.php:1089  do_action( 'wpcf7_submit', ... )
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+cv_need_change( 'includes/formhelpers/class-checkview-cf7-helper.php', 'pending_test_id', 'PR #241' );
+
+define( 'WPINC', 1 );
+define( 'TEST_EMAIL', 'test@test-mail.checkview.io' );
+
+$GLOBALS['cv_log']      = array();
+$GLOBALS['cv_actions']  = array();
+$GLOBALS['cv_filters']  = array();
+$GLOBALS['cv_opts']     = array();
+$GLOBALS['cv_complete'] = 0;
+
+function add_action( $tag, $cb, $priority = 10, $args = 1 ) { $GLOBALS['cv_actions'][ $tag ][] = array( 'cb' => $cb, 'priority' => $priority ); }
+function add_filter( $tag, $cb, $priority = 10, $args = 1 ) { $GLOBALS['cv_filters'][ $tag ][] = array( 'cb' => $cb, 'priority' => $priority ); }
+function apply_filters( $tag, $value ) {
+	foreach ( $GLOBALS['cv_filters'][ $tag ] ?? array() as $c ) { $value = call_user_func( $c['cb'], $value ); }
+	return $value;
+}
+function do_action( $tag, ...$args ) {
+	foreach ( $GLOBALS['cv_actions'][ $tag ] ?? array() as $c ) { call_user_func_array( $c['cb'], $args ); }
+}
+function __return_false() { return false; }
+function __return_true() { return true; }
+function __return_null() { return null; }
+function get_option( $k, $d = false ) { return $GLOBALS['cv_opts'][ $k ] ?? $d; }
+function wp_json_encode( $v ) { return json_encode( $v ); }
+function get_checkview_test_id() { return 'cv-test-123'; }
+function esc_html__( $s, $d = '' ) { return $s; }
+function current_time( $t ) { return '2026-01-01 00:00:00'; }
+function sanitize_url( $u ) { return $u; }
+function wp_unslash( $v ) { return $v; }
+function maybe_unserialize( $v ) { return $v; }
+function checkview_truncate_meta_key( $k ) { return $k; }
+function cv_should_allow_original_recipients() { return false; }
+function cv_append_test_email_array( $r ) { return (array) $r; }
+function cv_append_test_email_string( $r ) { return (string) $r; }
+function cv_inject_reply_to_header( $h ) { return $h; }
+
+/** The real thing deletes disable_email_receipt_<id> — that is the whole point. */
+function complete_checkview_test( $id ) {
+	$GLOBALS['cv_complete']++;
+	unset( $GLOBALS['cv_opts'][ 'disable_email_receipt_' . $id ] );
+}
+
+class Checkview_Loader {}
+class Checkview_Admin_Logs {
+	public static function add( $c, $m ) { $GLOBALS['cv_log'][] = $m; }
+}
+
+require_once CV_PLUGIN_DIR . '/includes/formhelpers/class-checkview-cf7-helper.php';
+
+
+$h = ( new ReflectionClass( 'Checkview_CF7_Helper' ) )->newInstanceWithoutConstructor();
+
+echo "\n=== hook wiring ===\n";
+// Re-run the constructor's registrations against our registry.
+$GLOBALS['cv_actions'] = array();
+$GLOBALS['cv_filters'] = array();
+( new ReflectionMethod( 'Checkview_CF7_Helper', '__construct' ) )->invoke( $h );
+cv_ok( ! empty( $GLOBALS['cv_actions']['wpcf7_submit'] ), 'completion now hooked on wpcf7_submit' );
+cv_ok( ! empty( $GLOBALS['cv_actions']['wpcf7_before_send_mail'] ), 'clone still on wpcf7_before_send_mail' );
+
+/**
+ * Runs CF7's real order: completion hook fires BEFORE the email filter.
+ * Returns what the email filter saw.
+ */
+function cf7_submit_sequence( $h, bool $keep_original ) {
+	$GLOBALS['cv_opts']     = $keep_original ? array( 'disable_email_receipt_cv-test-123' => 'true' ) : array();
+	$GLOBALS['cv_complete'] = 0;
+
+	// submission.php:111 — before_send_mail. Stand in for the clone handler by
+	// setting the pending id the way it does.
+	$rp = new ReflectionProperty( 'Checkview_CF7_Helper', 'pending_test_id' );
+	$rp->setAccessible( true );
+	$rp->setValue( $h, 'cv-test-123' );
+
+	// submission.php:123 -> mail.php:239 — the email filter.
+	$args = $h->checkview_inject_email(
+		array( 'recipient' => 'real@customer.test', 'additional_headers' => "Cc: cc@customer.test\nBcc: bcc@customer.test" )
+	);
+
+	// contact-form.php:1089 — wpcf7_submit.
+	$h->checkview_cf7_complete_after_submit();
+
+	return array( 'args' => $args, 'complete' => $GLOBALS['cv_complete'] );
+}
+
+echo "\n=== keep-original-recipient mode now actually works ===\n";
+$r = cf7_submit_sequence( $h, true );
+cv_ok( false !== strpos( $r['args']['recipient'], 'real@customer.test' ), "the customer's recipient is PRESERVED" );
+cv_ok( false !== strpos( $r['args']['recipient'], TEST_EMAIL ), 'and the test inbox is appended' );
+cv_ok( 1 === $r['complete'], 'test still completes' );
+
+echo "\n=== replace mode unchanged ===\n";
+$r = cf7_submit_sequence( $h, false );
+cv_ok( TEST_EMAIL === $r['args']['recipient'], 'recipient replaced with the test inbox' );
+cv_ok( false === stripos( $r['args']['additional_headers'], 'Cc:' ), 'Cc stripped' );
+cv_ok( false === stripos( $r['args']['additional_headers'], 'Bcc:' ), 'Bcc stripped' );
+cv_ok( 1 === $r['complete'], 'test completes' );
+
+echo "\n=== the OLD order is what broke it ===\n";
+$GLOBALS['cv_opts'] = array( 'disable_email_receipt_cv-test-123' => 'true' );
+complete_checkview_test( 'cv-test-123' );          // what before_send_mail used to do
+$args = $h->checkview_inject_email( array( 'recipient' => 'real@customer.test', 'additional_headers' => '' ) );
+cv_ok( TEST_EMAIL === $args['recipient'], 'completing first makes keep-original UNREACHABLE (recipient replaced)' );
+cv_ok( false === strpos( $args['recipient'], 'real@customer.test' ), "the customer's recipient was dropped" );
+
+echo "\n=== completion is idempotent and does not fire without a pending id ===\n";
+$GLOBALS['cv_complete'] = 0;
+$rp = new ReflectionProperty( 'Checkview_CF7_Helper', 'pending_test_id' );
+$rp->setAccessible( true );
+$rp->setValue( $h, 'cv-test-123' );
+$h->checkview_cf7_complete_after_submit();
+$h->checkview_cf7_complete_after_submit();
+cv_ok( 1 === $GLOBALS['cv_complete'], 'completes exactly once across two wpcf7_submit firings' );
+
+$GLOBALS['cv_complete'] = 0;
+$rp->setValue( $h, '' );
+$h->checkview_cf7_complete_after_submit();
+cv_ok( 0 === $GLOBALS['cv_complete'], 'no pending id (e.g. validation failed) -> does not complete' );
+
+cv_finish();

--- a/tests/harness/cases/cf7_legacy_shortcode.php
+++ b/tests/harness/cases/cf7_legacy_shortcode.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Verification for the legacy [contact-form] discovery patterns.
+ *
+ * The pattern templates are read from the shipped API file and evaluated with
+ * real SQL LIKE semantics against content CF7 actually produces.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+cv_need_fixture( 'contact-form-7' );
+cv_need_change( 'includes/API/class-checkview-api.php', '_old_cf7_unit_id', 'PR #245' );
+
+$API = CV_PLUGIN_DIR . '/includes/API/class-checkview-api.php';
+$CF7 = CV_FIXTURES . '/contact-form-7/';
+
+
+
+echo "\n=== CF7 really does still register the legacy tag ===\n";
+$load = file_get_contents( $CF7 . 'load.php' );
+cv_ok(
+	(bool) preg_match( "/add_shortcode\(\s*'contact-form-7',\s*'wpcf7_contact_form_tag_func'\s*\)/", $load ),
+	'registers [contact-form-7]'
+);
+cv_ok(
+	(bool) preg_match( "/add_shortcode\(\s*'contact-form',\s*'wpcf7_contact_form_tag_func'\s*\)/", $load ),
+	'AND registers [contact-form] to the same callback'
+);
+
+echo "\n=== and it resolves that tag by _old_cf7_unit_id, not post ID ===\n";
+$fns = file_get_contents( $CF7 . 'includes/contact-form-functions.php' );
+cv_ok(
+	(bool) preg_match( "/if \(\s*'contact-form-7' === \\\$code \)/", $fns ),
+	'the callback branches on which tag was used'
+);
+cv_ok(
+	(bool) preg_match( '/\$id = \(int\) array_shift\( \$atts \);\s*\n\s*\$contact_form = wpcf7_get_contact_form_by_old_id\( \$id \);/', $fns ),
+	'the legacy branch takes the first positional att and resolves it by OLD id'
+);
+cv_ok(
+	(bool) preg_match( "/'key' => '_old_cf7_unit_id'/", $fns ),
+	'which is a lookup on the _old_cf7_unit_id post meta'
+);
+
+echo "\n=== the shipped patterns ===\n";
+$api = file_get_contents( $API );
+cv_ok(
+	(bool) preg_match( "/get_post_meta\(\s*\\\$row->ID,\s*'_old_cf7_unit_id',\s*true\s*\)/", $api ),
+	'the helper reads _old_cf7_unit_id (not the post ID) for these patterns'
+);
+cv_ok(
+	(bool) preg_match( "/if \(\s*'' !== \\\$old_unit_id && is_numeric\( \\\$old_unit_id \)/", $api ),
+	'and only adds patterns when that meta exists and is numeric'
+);
+
+preg_match_all( "/\\\$cf7_patterns\[\] = '%\[contact-form ' \. \\\$old_unit_id \. '(.*?)';/", $api, $pm );
+cv_ok( 2 === count( $pm[1] ), 'found both legacy pattern templates (got ' . count( $pm[1] ) . ')' );
+
+$old_id   = 1;
+$patterns = array();
+foreach ( $pm[1] as $tail ) {
+	$patterns[] = '%[contact-form ' . $old_id . $tail;
+}
+
+$matches = function ( string $content ) use ( $patterns ): bool {
+	foreach ( $patterns as $p ) {
+		if ( cv_like( $p, $content ) ) { return true; }
+	}
+	return false;
+};
+
+echo "\n=== finds real legacy placements ===\n";
+cv_ok( $matches( 'Intro [contact-form 1] outro' ), 'plain [contact-form 1]' );
+cv_ok( $matches( '[contact-form 1 "Contact form 1"]' ), '[contact-form 1 "Title"] (the form CF7 itself emitted)' );
+cv_ok( $matches( "<p>text</p>\n[contact-form 1]\n<p>more</p>" ), 'across newlines' );
+
+echo "\n=== does not steal other forms' pages ===\n";
+cv_ok( ! $matches( '[contact-form 12]' ), 'old id 1 does NOT match [contact-form 12]' );
+cv_ok( ! $matches( '[contact-form 123 "x"]' ), 'old id 1 does NOT match [contact-form 123 "x"]' );
+cv_ok( ! $matches( '[contact-form 10]' ), 'old id 1 does NOT match [contact-form 10]' );
+
+echo "\n=== stays out of the modern tag's territory ===\n";
+cv_ok( ! $matches( '[contact-form-7 id="1"]' ), 'does not match [contact-form-7 id="1"]' );
+cv_ok( ! $matches( '[contact-form-7 id="abc1234" title="X"]' ), 'does not match a hash-id [contact-form-7]' );
+cv_ok( ! $matches( '[contact-form-71]' ), 'does not match [contact-form-71]' );
+
+echo "\n=== the unbounded form would have been wrong ===\n";
+$unbounded = '%[contact-form ' . $old_id;
+cv_ok( cv_like( $unbounded . '%', '[contact-form 12]' ), 'an unterminated pattern WOULD have matched [contact-form 12]' );
+cv_ok( ! $matches( '[contact-form 12]' ), 'the shipped patterns are terminated, so they do not' );
+
+cv_finish();

--- a/tests/harness/cases/formidable_cleantalk.php
+++ b/tests/harness/cases/formidable_cleantalk.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Verification for the CleanTalk bypass in the Formidable helper.
+ *
+ * The bypass leans on an INTERNAL CleanTalk global, so every link in the chain
+ * is asserted against CleanTalk's shipped source rather than described. If
+ * CleanTalk moves the sentinel, changes the default `allow`, or changes the
+ * caller's block condition, these fail instead of the bypass silently dying.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+cv_need_fixture( 'cleantalk-spam-protect' );
+cv_need_change( 'includes/formhelpers/class-checkview-formidable-helper.php', 'cleantalk_executed', 'PR #243' );
+
+$CT     = CV_FIXTURES . '/cleantalk-spam-protect/';
+$HELPER = CV_PLUGIN_DIR . '/includes/formhelpers/class-checkview-formidable-helper.php';
+
+
+$common      = file_get_contents( $CT . 'inc/cleantalk-common.php' );
+$integr      = file_get_contents( $CT . 'inc/cleantalk-public-integrations.php' );
+$ajax        = file_get_contents( $CT . 'inc/cleantalk-ajax.php' );
+$main        = file_get_contents( $CT . 'cleantalk.php' );
+$response    = file_get_contents( $CT . 'lib/Cleantalk/Antispam/CleantalkResponse.php' );
+$helper_src  = file_get_contents( $HELPER );
+
+echo "\n=== CleanTalk really does integrate with Formidable ===\n";
+cv_ok(
+	(bool) preg_match( "/add_filter\('frm_entries_before_create',\s*'apbct_form__formidable__testSpam',\s*(\d+)/", $main, $m1 ),
+	'registers apbct_form__formidable__testSpam on frm_entries_before_create'
+);
+cv_ok( isset( $m1[1] ) && '999999' === $m1[1], 'at priority 999999, i.e. after everything (got ' . ( $m1[1] ?? '?' ) . ')' );
+cv_ok(
+	(bool) preg_match( "/add_action\('wp_ajax_nopriv_frm_entries_create',\s*'ct_ajax_hook',\s*(\d+)\)/", $ajax, $m2 ),
+	'and ct_ajax_hook on wp_ajax_nopriv_frm_entries_create'
+);
+cv_ok( isset( $m2[1] ) && '1' === $m2[1], 'at priority 1, i.e. before Formidable handles it (got ' . ( $m2[1] ?? '?' ) . ')' );
+
+echo "\n=== both paths funnel into the sentinel-guarded call ===\n";
+cv_ok( false !== strpos( $integr, 'apbct_base_call(' ), 'the Formidable integration calls apbct_base_call()' );
+cv_ok( false !== strpos( $ajax, 'apbct_base_call(' ), 'the ajax path calls apbct_base_call() too' );
+
+// Nothing may terminate the ajax path before it reaches that call, or the
+// sentinel would never be consulted.
+$ajax_lines = explode( "\n", $ajax );
+$hook_start = null;
+$call_line  = null;
+foreach ( $ajax_lines as $i => $line ) {
+	if ( null === $hook_start && false !== strpos( $line, 'function ct_ajax_hook' ) ) { $hook_start = $i; }
+	if ( null !== $hook_start && null === $call_line && false !== strpos( $line, 'apbct_base_call(' ) ) { $call_line = $i; }
+}
+cv_ok( null !== $hook_start && null !== $call_line, 'located ct_ajax_hook and its base_call' );
+$between = implode( "\n", array_slice( $ajax_lines, $hook_start, $call_line - $hook_start ) );
+cv_ok(
+	0 === preg_match( '/\bct_die\(|\bwp_die\(|\bwp_send_json/', $between ),
+	'no termination between ct_ajax_hook and that call, so the sentinel is always reached'
+);
+
+echo "\n=== the sentinel short-circuits to ALLOW, not to block ===\n";
+cv_ok(
+	(bool) preg_match( '/global \$cleantalk_executed;.*?if \(\s*\$cleantalk_executed\s*\)\s*\{.*?return array\(\s*\'ct_result\'\s*=>\s*new CleantalkResponse\(\)\s*\);/s', $common ),
+	'apbct_base_call() returns a default CleantalkResponse when the sentinel is set'
+);
+cv_ok(
+	(bool) preg_match( '/\$this->allow\s*=\s*isset\(\$obj->allow\)\s*\?\s*\$obj->allow\s*:\s*(\d+);/', $response, $m3 ),
+	'CleantalkResponse defaults `allow`'
+);
+cv_ok(
+	isset( $m3[1] ) && '1' === $m3[1],
+	'and that default is 1 = allowed (got ' . ( $m3[1] ?? '?' ) . ') — 0 would BLOCK every submission'
+);
+cv_ok(
+	(bool) preg_match( '/if\s*\(\s*\$ct_result->allow\s*==\s*0\s*\)/', $integr ),
+	'the Formidable integration only blocks when allow == 0'
+);
+
+echo "\n=== the helper sets it ===\n";
+cv_ok(
+	(bool) preg_match( '/global \$cleantalk_executed;\s*\n\s*\$cleantalk_executed = true;/', $helper_src ),
+	'the Formidable helper sets the sentinel'
+);
+// It must be in the constructor: set after the submission hooks have run is useless.
+cv_ok(
+	(bool) preg_match( '/public function __construct\(\).*?global \$cleantalk_executed;\s*\n\s*\$cleantalk_executed = true;.*?\n\t\t\}/s', $helper_src ),
+	'inside the constructor, so it is set before any submission hook fires'
+);
+
+echo "\n=== executable: replay the real semantics ===\n";
+// Faithful to inc/cleantalk-common.php:110-124 and CleantalkResponse.php:154.
+class CleantalkResponse { public $allow = 1; public $comment = ''; }
+function apbct_base_call( $params = array() ) {
+	global $cleantalk_executed;
+	if ( $cleantalk_executed ) {
+		return array( 'ct_result' => new CleantalkResponse() );
+	}
+	$r          = new CleantalkResponse();
+	$r->allow   = 0;                       // stand in for "the API called it spam"
+	$r->comment = 'Blocked by CleanTalk';
+	return array( 'ct_result' => $r );
+}
+/** The shape of apbct_form__formidable__testSpam's decision. */
+function formidable_would_block(): bool {
+	$res = apbct_base_call();
+	return isset( $res['ct_result'] ) && 0 == $res['ct_result']->allow;
+}
+
+$GLOBALS['cleantalk_executed'] = false;
+cv_ok( true === formidable_would_block(), 'precondition: without the bypass, a flagged submission is blocked' );
+
+// What the helper's constructor does.
+$GLOBALS['cleantalk_executed'] = true;
+cv_ok( false === formidable_would_block(), 'with the sentinel set, the submission is allowed through' );
+
+cv_finish();

--- a/tests/harness/cases/formidable_entryid_guard.php
+++ b/tests/harness/cases/formidable_entryid_guard.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Verification for the non-positive entry-id guard in the Formidable clone
+ * handler.
+ *
+ * The child-entry cleanup queries `WHERE parent_item_id = %d`, and Formidable
+ * stores 0 in that column for every TOP-LEVEL entry
+ * (FrmMigrate.php:234 — `parent_item_id BIGINT(20) default 0`). So an entry_id of
+ * 0 would select the customer's whole entry table and then delete it.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+cv_need_change( 'includes/formhelpers/class-checkview-formidable-helper.php', 'parent_item_id', 'PR #234' );
+
+define( 'WPINC', 1 );
+define( 'TEST_EMAIL', 'test@test-mail.checkview.io' );
+
+$GLOBALS['cv_log']      = array();
+$GLOBALS['cv_complete'] = 0;
+
+function add_filter( ...$a ) {}
+function add_action( ...$a ) {}
+function apply_filters( $t, $v ) { return $v; }
+function __return_false() { return false; }
+function __return_true() { return true; }
+function __return_null() { return null; }
+function get_option( $k, $d = false ) { return $d; }
+function wp_json_encode( $v ) { return json_encode( $v ); }
+function current_time( $t ) { return '2026-01-01 00:00:00'; }
+function sanitize_url( $u ) { return $u; }
+function wp_unslash( $v ) { return $v; }
+function maybe_unserialize( $v ) { return $v; }
+function checkview_truncate_meta_key( $k ) { return $k; }
+function get_checkview_test_id() { return 'cv-test-123'; }
+function complete_checkview_test( $id ) { $GLOBALS['cv_complete']++; }
+function esc_html__( $s, $d = '' ) { return $s; }
+function cv_should_allow_original_recipients() { return false; }
+function cv_append_test_email_array( $r ) { return (array) $r; }
+function cv_append_test_email_string( $r ) { return (string) $r; }
+function cv_inject_reply_to_header( $h ) { return $h; }
+
+class Checkview_Loader {}
+class Checkview_Admin_Logs {
+	public static function add( $c, $m ) { $GLOBALS['cv_log'][] = $m; }
+}
+class FrmField {
+	public static function get_field_type( $f ) { return 'text'; }
+}
+
+class Fake_WPDB {
+	public $prefix = 'wp_';
+	public $last_error = '';
+	public $is_draft = 0;
+	/** What a `WHERE parent_item_id = 0` query would return: every top-level entry. */
+	public $child_ids = array( 950, 951, 952 );
+	public $inserts = array();
+	public $deletes = array();
+	public function prepare( $sql, ...$args ) {
+		foreach ( $args as $a ) {
+			if ( is_array( $a ) ) {
+				foreach ( $a as $v ) { $sql = preg_replace( '/%d/', (string) (int) $v, $sql, 1 ); }
+				continue;
+			}
+			$sql = preg_replace( '/%[ds]/', is_numeric( $a ) ? (string) $a : "'" . $a . "'", $sql, 1 );
+		}
+		return $sql;
+	}
+	public function insert( $t, $d ) { $this->inserts[ $t ][] = $d; return 1; }
+	public function get_var( $sql ) { return false !== strpos( $sql, 'is_draft' ) ? $this->is_draft : null; }
+	public function get_results( $sql ) { return array(); }
+	public function get_col( $sql ) { return false !== strpos( $sql, 'parent_item_id' ) ? $this->child_ids : array(); }
+	public function query( $sql ) {
+		if ( 0 === stripos( ltrim( $sql ), 'DELETE' ) ) { $this->deletes[] = preg_replace( '/\s+/', ' ', trim( $sql ) ); }
+		return 1;
+	}
+}
+
+require_once CV_PLUGIN_DIR . '/includes/formhelpers/class-checkview-formidable-helper.php';
+
+
+$h = ( new ReflectionClass( 'Checkview_Formidable_Helper' ) )->newInstanceWithoutConstructor();
+
+function run( $h, $entry_id ) {
+	global $wpdb;
+	$wpdb = new Fake_WPDB();
+	$GLOBALS['cv_log'] = array();
+	$GLOBALS['cv_complete'] = 0;
+	$h->checkview_log_form_test_entry( $entry_id, 7, array() );
+	return array( 'deletes' => $wpdb->deletes, 'inserts' => $wpdb->inserts, 'complete' => $GLOBALS['cv_complete'], 'log' => implode( ' | ', $GLOBALS['cv_log'] ) );
+}
+
+echo "\n=== non-positive entry ids must not reach the database ===\n";
+foreach ( array( 0, -1, '0', 'not-a-number', null ) as $bad ) {
+	$label = var_export( $bad, true );
+	$r     = run( $h, $bad );
+	cv_ok( empty( $r['deletes'] ), "entry_id $label: NO delete statements issued" );
+	cv_ok( empty( $r['inserts'] ), "entry_id $label: nothing cloned" );
+	cv_ok( 0 === $r['complete'], "entry_id $label: test not completed" );
+}
+cv_ok( false !== strpos( run( $h, 0 )['log'], 'non-positive entry id' ), 'logs the refusal' );
+
+echo "\n=== the danger is real: what the unguarded query would have done ===\n";
+$db = new Fake_WPDB();
+$sql = $db->prepare( 'SELECT id FROM wp_frm_items WHERE parent_item_id=%d', 0 );
+cv_ok( 'SELECT id FROM wp_frm_items WHERE parent_item_id=0' === $sql, 'entry_id 0 builds a parent_item_id=0 query' );
+cv_ok( 3 === count( $db->get_col( $sql ) ), 'which matches every top-level entry (0 is the DEFAULT for those)' );
+
+echo "\n=== a valid entry id still works ===\n";
+$r = run( $h, 902 );
+cv_ok( ! empty( $r['inserts']['wp_cv_entry'] ), 'cv_entry row written' );
+cv_ok( ! empty( $r['deletes'] ), 'deletes issued' );
+cv_ok( 1 === $r['complete'], 'test completed once' );
+$joined = implode( ' ;; ', $r['deletes'] );
+cv_ok( false !== strpos( $joined, 'parent_item_id=902' ), 'child cleanup scoped to the real parent id' );
+cv_ok( false === strpos( $joined, 'parent_item_id=0' ), 'never emits parent_item_id=0' );
+
+cv_finish();

--- a/tests/harness/cases/formidable_form_list.php
+++ b/tests/harness/cases/formidable_form_list.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Verification for the Formidable form-list filter.
+ *
+ * The WHERE clause is EXECUTED against a real (SQLite) frm_forms table holding
+ * the row shapes Formidable actually produces, rather than pattern-matched. The
+ * clause itself is extracted from the shipped plugin file, so it cannot drift.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+cv_need_fixture( 'formidable' );
+cv_need_change( 'includes/API/class-checkview-api.php', 'get_published_forms', 'PR #244' );
+if ( ! in_array( 'sqlite', PDO::getAvailableDrivers(), true ) ) {
+	cv_skip( 'pdo_sqlite is not available — this case executes the WHERE clause against a real table' );
+}
+
+$API = CV_PLUGIN_DIR . '/includes/API/class-checkview-api.php';
+$FRM = CV_FIXTURES . '/formidable/classes/models/FrmForm.php';
+
+
+$db = new PDO( 'sqlite::memory:' );
+$db->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+$db->exec(
+	'CREATE TABLE frm_forms (
+		id INTEGER PRIMARY KEY, name TEXT, status TEXT,
+		is_template INTEGER DEFAULT 0, parent_form_id INTEGER DEFAULT 0
+	)'
+);
+
+/**
+ * The row shapes Formidable actually produces.
+ * Fixture => [status, is_template, parent_form_id, should_be_listed]
+ */
+$rows = array(
+	'ordinary published form'      => array( 'published', 0, 0, true ),
+	'form with NULL status'        => array( null, 0, 0, true ),
+	'form with empty status'       => array( '', 0, 0, true ),
+	'form with NULL parent column' => array( 'published', 0, null, true ),
+	'a TEMPLATE'                   => array( 'published', 1, 0, false ),
+	'a template, NULL status'      => array( null, 1, 0, false ),
+	'a CHILD form (repeater)'      => array( 'published', 0, 7, false ),
+	'a trashed form'               => array( 'trash', 0, 0, false ),
+	'a draft form'                 => array( 'draft', 0, 0, false ),
+);
+$i = 0;
+foreach ( $rows as $label => $r ) {
+	$st = $db->prepare( 'INSERT INTO frm_forms (id,name,status,is_template,parent_form_id) VALUES (?,?,?,?,?)' );
+	$st->execute( array( ++$i, $label, $r[0], $r[1], $r[2] ) );
+}
+
+echo "\n=== the clause is Formidable's own (read from FrmForm.php) ===\n";
+$frm = file_get_contents( $FRM );
+preg_match( '/public static function get_published_forms\(.*?\n\t\}/s', $frm, $gm );
+$gp = $gm[0] ?? '';
+cv_ok( '' !== $gp, 'extracted FrmForm::get_published_forms()' );
+cv_ok( false !== strpos( $gp, "\$query['is_template'] = 0;" ), 'upstream excludes templates' );
+cv_ok(
+	(bool) preg_match( "/\\\$query\['status'\]\s*=\s*array\(\s*null,\s*'',\s*'published'\s*\)/", $gp ),
+	"upstream treats NULL and '' as published"
+);
+cv_ok(
+	(bool) preg_match( "/\\\$query\['parent_form_id'\]\s*=\s*array\(\s*null,\s*0\s*\)/", $gp ),
+	'upstream excludes child forms (NULL or 0 parent)'
+);
+
+echo "\n=== extract the shipped WHERE clause and run it ===\n";
+$api = file_get_contents( $API );
+preg_match(
+	"/'SELECT \* FROM ' \. \\\$tablename \. \"(.*?)\",\s*0,\s*'published',\s*0/s",
+	$api,
+	$m
+);
+cv_ok( ! empty( $m[1] ), 'extracted the fallback WHERE clause from the shipped file' );
+
+$clause = $m[1] ?? '';
+// Substitute wpdb placeholders positionally: %d, %s, %d -> 0, 'published', 0.
+$sql_new = 'SELECT id, name FROM frm_forms ' . $clause;
+$sql_new = preg_replace( '/%d/', '0', $sql_new, 1 );
+$sql_new = preg_replace( '/%s/', "'published'", $sql_new, 1 );
+$sql_new = preg_replace( '/%d/', '0', $sql_new, 1 );
+
+$got = array();
+foreach ( $db->query( $sql_new )->fetchAll( PDO::FETCH_ASSOC ) as $r ) { $got[] = $r['name']; }
+
+foreach ( $rows as $label => $r ) {
+	$listed = in_array( $label, $got, true );
+	cv_ok( $listed === $r[3], ( $r[3] ? 'lists' : 'excludes' ) . ": $label" );
+}
+
+echo "\n=== the OLD clause is what caused it ===\n";
+$old = array();
+foreach ( $db->query( "SELECT id, name FROM frm_forms WHERE 1=1 AND status='published'" )->fetchAll( PDO::FETCH_ASSOC ) as $r ) {
+	$old[] = $r['name'];
+}
+cv_ok( in_array( 'a TEMPLATE', $old, true ), 'old query listed templates as testable' );
+cv_ok( in_array( 'a CHILD form (repeater)', $old, true ), 'old query listed child forms as testable' );
+cv_ok( ! in_array( 'form with NULL status', $old, true ), 'old query MISSED forms with NULL status' );
+cv_ok( ! in_array( 'form with empty status', $old, true ), "old query MISSED forms with '' status" );
+// This one the old query got right (it is published); the point is that adding
+// the parent_form_id condition must not start excluding it, since a NULL parent
+// means top-level exactly as 0 does.
+cv_ok( in_array( 'form with NULL parent column', $old, true ), 'old query listed NULL-parent forms, and the new clause still does' );
+
+echo "\n=== prefers Formidable's own API when it is loadable ===\n";
+cv_ok(
+	(bool) preg_match( "/is_callable\(\s*array\(\s*'FrmForm',\s*'get_published_forms'\s*\)\s*\)/", $api ),
+	'guards on is_callable() rather than assuming the class is loaded'
+);
+cv_ok(
+	(bool) preg_match( '/FrmForm::get_published_forms\(\s*array\(\),\s*(\d+)\s*\)/', $api, $lm ),
+	'calls the API with an explicit limit'
+);
+cv_ok(
+	isset( $lm[1] ) && (int) $lm[1] > 999,
+	'and that limit exceeds the 999 default, so large sites are not truncated (got ' . ( $lm[1] ?? '?' ) . ')'
+);
+
+cv_finish();

--- a/tests/harness/cases/forminator_helper.php
+++ b/tests/harness/cases/forminator_helper.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Behavioural verification for the Forminator helper.
+ *
+ * Drives the REAL methods. Critically, the entry id is supplied the way FORMINATOR
+ * supplies it — via the entry object on the pre-save hook — not by hand-feeding
+ * $response['entry_id'], which only exists for leads forms
+ * (front-action.php:1809-1810) and whose absence is what broke the earlier
+ * revision.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+cv_need_change( 'includes/formhelpers/class-checkview-forminator-helper.php', 'checkview_capture_entry_id', 'PR #238' );
+
+define( 'WPINC', 1 );
+define( 'TEST_EMAIL', 'test@test-mail.checkview.io' );
+
+$GLOBALS['cv_log']      = array();
+$GLOBALS['cv_filters']  = array();
+$GLOBALS['cv_actions']  = array();
+$GLOBALS['cv_opts']     = array();
+$GLOBALS['cv_complete'] = 0;
+$GLOBALS['cv_deleted']  = array();
+
+function add_filter( $tag, $cb, $priority = 10, $args = 1 ) {
+	$GLOBALS['cv_filters'][ $tag ][] = array( 'cb' => $cb, 'priority' => $priority );
+}
+function add_action( $tag, $cb, $priority = 10, $args = 1 ) {
+	$GLOBALS['cv_actions'][ $tag ][] = array( 'cb' => $cb, 'priority' => $priority );
+}
+function apply_filters( $tag, $value ) {
+	$extra = array_slice( func_get_args(), 2 );
+	if ( empty( $GLOBALS['cv_filters'][ $tag ] ) ) { return $value; }
+	$cbs = $GLOBALS['cv_filters'][ $tag ];
+	usort( $cbs, fn( $a, $b ) => $a['priority'] <=> $b['priority'] );
+	foreach ( $cbs as $c ) { $value = call_user_func_array( $c['cb'], array_merge( array( $value ), $extra ) ); }
+	return $value;
+}
+function __return_false() { return false; }
+function __return_true() { return true; }
+function __return_null() { return null; }
+function get_option( $k, $d = false ) { return $GLOBALS['cv_opts'][ $k ] ?? $d; }
+function wp_json_encode( $v ) { return json_encode( $v ); }
+function current_time( $t ) { return '2026-01-01 00:00:00'; }
+function sanitize_url( $u ) { return $u; }
+function wp_unslash( $v ) { return $v; }
+function maybe_serialize( $v ) { return is_array( $v ) || is_object( $v ) ? serialize( $v ) : $v; }
+function maybe_unserialize( $v ) { return $v; }
+function checkview_truncate_meta_key( $k ) { return $k; }
+function get_checkview_test_id() { return 'cv-test-123'; }
+function complete_checkview_test( $id ) { $GLOBALS['cv_complete']++; }
+function esc_html__( $s, $d = '' ) { return $s; }
+function cv_should_allow_original_recipients() { return false; }
+function cv_append_test_email_array( $r ) { return (array) $r; }
+function cv_append_test_email_string( $r ) { return (string) $r; }
+function cv_inject_reply_to_header( $h ) { return $h; }
+
+class Checkview_Loader {}
+class Checkview_Admin_Logs {
+	public static function add( $c, $m ) { $GLOBALS['cv_log'][] = $m; }
+}
+class Forminator_Form_Entry_Model {
+	public static $rows = array();
+	public $entry_id = 0;
+	public $form_id  = 0;
+	public $status    = 'active';
+	public $meta_data = array();
+	public function __construct( $entry_id = 0 ) {
+		if ( isset( self::$rows[ $entry_id ] ) ) {
+			$this->entry_id  = $entry_id;
+			$this->form_id   = self::$rows[ $entry_id ]['form_id'] ?? 7;
+			$this->status    = self::$rows[ $entry_id ]['status'];
+			$this->meta_data = self::$rows[ $entry_id ]['meta'];
+		}
+	}
+	public static function delete_by_entry( $id ) { $GLOBALS['cv_deleted'][] = $id; }
+}
+class Fake_WPDB {
+	public $prefix = 'wp_';
+	public $last_error = '';
+	public $inserts = array();
+	public function insert( $t, $d ) { $this->inserts[ $t ][] = $d; return 1; }
+}
+
+$_SERVER['HTTP_REFERER'] = 'https://example.test/contact/';
+
+require_once CV_PLUGIN_DIR . '/includes/formhelpers/class-checkview-forminator-helper.php';
+
+
+$h = new Checkview_Forminator_Helper();
+
+echo "\n=== hook wiring ===\n";
+cv_ok( ! empty( $GLOBALS['cv_actions']['forminator_custom_form_submit_before_set_fields'] ), 'capture hook registered' );
+cv_ok( 1 === $GLOBALS['cv_actions']['forminator_custom_form_submit_before_set_fields'][0]['priority'], 'capture at priority 1' );
+cv_ok( ! empty( $GLOBALS['cv_actions']['forminator_form_after_save_entry'] ), 'AJAX act hook registered' );
+cv_ok( ! empty( $GLOBALS['cv_actions']['forminator_form_after_handle_submit'] ), 'NON-AJAX act hook registered (forms POST unless AJAX is enabled)' );
+// The original guarantee here was "nothing is deferred to shutdown" — the clone,
+// delete and completion all run inline on the post-save hooks. A shutdown hook
+// now exists, but it is diagnostic only, so assert the intent rather than the
+// mere absence of the hook.
+// NB: the helper file instantiates itself at the bottom, and this harness then
+// constructs it again — so EVERY hook appears twice in this registry. Assert on
+// callback identity, not on count, or the artifact reads as a defect.
+$shutdown_cbs = $GLOBALS['cv_actions']['shutdown'] ?? array();
+cv_ok( ! empty( $shutdown_cbs ), 'a shutdown callback is registered' );
+$shutdown_methods = array_unique(
+	array_map(
+		fn( $c ) => is_array( $c['cb'] ) ? $c['cb'][1] : (string) $c['cb'],
+		$shutdown_cbs
+	)
+);
+cv_ok(
+	array( 'checkview_log_unfinished_submission' ) === array_values( $shutdown_methods ),
+	'and the ONLY thing on shutdown is the diagnostic, never the clone handler (got: ' . implode( ', ', $shutdown_methods ) . ')'
+);
+foreach ( array( 'forminator_form_after_save_entry', 'forminator_form_after_handle_submit' ) as $act_tag ) {
+	$m = is_array( $GLOBALS['cv_actions'][ $act_tag ][0]['cb'] ?? null ) ? $GLOBALS['cv_actions'][ $act_tag ][0]['cb'][1] : '';
+	cv_ok( 'checkview_log_form_test_entry' === $m, "clone/complete still runs inline on {$act_tag}, not deferred" );
+}
+
+/**
+ * Simulates Forminator: capture hook receives the entry object, then the act hook
+ * fires with only ( $form_id, $response ) — and NO entry_id in $response, which is
+ * the real shape for a non-leads form.
+ */
+function submit( $h, int $entry_id, string $status, array $meta, string $act = 'forminator_form_after_save_entry', bool $leads = false ) {
+	global $wpdb;
+	$wpdb = new Fake_WPDB();
+	Forminator_Form_Entry_Model::$rows = $entry_id > 0
+		? array( $entry_id => array( 'status' => $status, 'meta' => $meta, 'form_id' => 7 ) )
+		: array();
+	$GLOBALS['cv_log'] = array();
+	$GLOBALS['cv_complete'] = 0;
+	$GLOBALS['cv_deleted'] = array();
+
+	// Pre-save hook: Forminator hands us the entry object.
+	$entry = new stdClass();
+	$entry->entry_id = $entry_id;   // 0 when prevent_store() skipped the save
+	$h->checkview_capture_entry_id( $entry, 7, array() );
+
+	// Act hook: $response has NO entry_id unless this is a leads form.
+	$response = $leads ? array( 'entry_id' => $entry_id, 'success' => true ) : array( 'success' => true );
+	$h->checkview_log_form_test_entry( 7, $response );
+
+	return array( 'inserts' => $wpdb->inserts, 'complete' => $GLOBALS['cv_complete'], 'deleted' => $GLOBALS['cv_deleted'], 'log' => implode( ' | ', $GLOBALS['cv_log'] ) );
+}
+function cloned( array $inserts, string $key ) {
+	foreach ( $inserts['wp_cv_entry_meta'] ?? array() as $row ) {
+		if ( $key === $row['meta_key'] ) { return $row['meta_value']; }
+	}
+	return null;
+}
+
+// value != label throughout: the SaaS comparison lowercases, strips punctuation
+// and falls back to substring containment, so value === label proves nothing.
+$meta = array(
+	'name-1'                    => array( 'id' => 1, 'value' => 'Alice' ),
+	'select-1'                  => array( 'id' => 2, 'value' => 'Premium Plan' ),
+	'checkbox-1'                => array( 'id' => 3, 'value' => array( 'Blue', 'Green' ) ),
+	'address-1'                 => array( 'id' => 4, 'value' => array( 'street' => '1 High St', 'city' => 'Leeds' ) ),
+	'_forminator_user_ip'       => array( 'id' => 5, 'value' => '203.0.113.9' ),
+	'_forminator_choice_values' => array( 'id' => 6, 'value' => array( 'select-1' => 'opt_1', 'checkbox-1' => array( 'c_blue', 'c_green' ) ) ),
+);
+
+echo "\n=== THE BUG THAT WAS FIXED: a NON-LEADS form has no entry_id in \$response ===\n";
+$r = submit( $h, 501, 'active', $meta );   // leads = false
+cv_ok( ! empty( $r['inserts']['wp_cv_entry'] ), 'cv_entry row written even though $response carries no entry_id' );
+cv_ok( array( 501 ) === $r['deleted'], 'the Forminator entry IS deleted' );
+cv_ok( 1 === $r['complete'], 'test completed once' );
+cv_ok( false === strpos( $r['log'], 'stored no entry' ), 'does NOT mistake a real submission for prevent_store' );
+
+echo "\n=== non-AJAX path uses the same handler ===\n";
+$r = submit( $h, 502, 'active', $meta, 'forminator_form_after_handle_submit' );
+cv_ok( ! empty( $r['inserts']['wp_cv_entry'] ), 'non-AJAX submission cloned' );
+cv_ok( 1 === $r['complete'], 'and completed' );
+
+echo "\n=== raw values, not labels ===\n";
+$r = submit( $h, 503, 'active', $meta );
+cv_ok( 'opt_1' === cloned( $r['inserts'], 'select-1' ), 'select sends raw opt_1, not the label' );
+cv_ok( 'Premium Plan' !== cloned( $r['inserts'], 'select-1' ), 'the label is definitively not sent' );
+cv_ok( 'c_blue, c_green' === cloned( $r['inserts'], 'checkbox-1' ), 'multi-value sends joined raw values' );
+cv_ok( '1 High St, Leeds' === cloned( $r['inserts'], 'address-1' ), 'composite joined, not serialized' );
+cv_ok( false === strpos( (string) cloned( $r['inserts'], 'address-1' ), 'a:2:' ), 'no serialized payload reaches the SaaS' );
+cv_ok( is_string( cloned( $r['inserts'], 'checkbox-1' ) ), 'field_value is a string' );
+$keys = array_column( $r['inserts']['wp_cv_entry_meta'], 'meta_key' );
+cv_ok( ! in_array( '_forminator_user_ip', $keys, true ), 'user_ip skipped' );
+cv_ok( ! in_array( '_forminator_choice_values', $keys, true ), 'choice_values skipped' );
+
+echo "\n=== prevent_store: entry never saved, so entry_id is genuinely 0 ===\n";
+$r = submit( $h, 0, 'active', array() );
+cv_ok( empty( $r['inserts'] ), 'nothing cloned' );
+cv_ok( empty( $r['deleted'] ), 'nothing deleted' );
+cv_ok( 1 === $r['complete'], 'test STILL completed — the notification was sent' );
+cv_ok( false !== strpos( $r['log'], 'stored no entry' ), 'logs why' );
+
+echo "\n=== spam ===\n";
+$r = submit( $h, 504, 'spam', $meta );
+cv_ok( empty( $r['inserts'] ), 'not cloned' );
+cv_ok( array( 504 ) === $r['deleted'], 'our own submission removed' );
+cv_ok( 0 === $r['complete'], 'NOT completed — no notification was sent' );
+
+echo "\n=== leads form still works (its \$response DOES carry entry_id) ===\n";
+$r = submit( $h, 505, 'active', $meta, 'forminator_form_after_save_entry', true );
+cv_ok( 1 === $r['complete'], 'leads submission completes' );
+
+echo "\n=== stale id cannot leak between submissions ===\n";
+global $wpdb;
+$wpdb = new Fake_WPDB();
+Forminator_Form_Entry_Model::$rows = array( 601 => array( 'status' => 'active', 'meta' => $meta, 'form_id' => 7 ) );
+$GLOBALS['cv_complete'] = 0; $GLOBALS['cv_deleted'] = array();
+$e = new stdClass(); $e->entry_id = 601;
+$h->checkview_capture_entry_id( $e, 7, array() );
+$h->checkview_log_form_test_entry( 7, array() );
+$first = $GLOBALS['cv_deleted'];
+// A second act WITHOUT a fresh capture must not re-use 601.
+$GLOBALS['cv_deleted'] = array();
+$h->checkview_log_form_test_entry( 7, array() );
+cv_ok( array( 601 ) === $first, 'first submission deleted 601' );
+cv_ok( empty( $GLOBALS['cv_deleted'] ), 'a later act with no capture does NOT re-delete 601 (id is cleared after use)' );
+
+echo "\n=== idempotence ===\n";
+$wpdb = new Fake_WPDB();
+Forminator_Form_Entry_Model::$rows = array( 701 => array( 'status' => 'active', 'meta' => $meta, 'form_id' => 7 ) );
+$GLOBALS['cv_complete'] = 0;
+$e = new stdClass(); $e->entry_id = 701;
+$h->checkview_capture_entry_id( $e, 7, array() );
+$h->checkview_log_form_test_entry( 7, array() );
+$h->checkview_capture_entry_id( $e, 7, array() );
+$h->checkview_log_form_test_entry( 7, array() );
+cv_ok( 1 === $GLOBALS['cv_complete'], 'duplicate submission completes only once' );
+cv_ok( 1 === count( $wpdb->inserts['wp_cv_entry'] ?? array() ), 'only one cv_entry row' );
+
+echo "\n=== hostile input ===\n";
+$h->checkview_capture_entry_id( null, 7, array() );
+$h->checkview_capture_entry_id( (object) array(), 7, array() );
+$h->checkview_log_form_test_entry( 7, 'not-an-array' );
+cv_ok( true, 'null entry, entry-less object and non-array response do not fatal' );
+
+echo "\n=== captcha + email + addons (unchanged behaviour) ===\n";
+$types = apply_filters( 'forminator_disabled_fields', array( 'stripe' ) );
+cv_ok( in_array( 'captcha', $types, true ) && in_array( 'stripe', $types, true ), 'captcha appended, stripe preserved' );
+cv_ok( false === apply_filters( 'hcap_activate', true ), 'hcap_activate false' );
+$hdrs = $h->checkview_remove_email_header( array( 'From: a@b.test', 'Cc: c@d.test', 'Bcc: e@f.test', 'Content-Type: text/html' ) );
+$j = implode( ' | ', $hdrs );
+cv_ok( false === stripos( $j, 'Cc:' ) && false === stripos( $j, 'Bcc:' ), 'Cc/Bcc stripped' );
+cv_ok( false !== strpos( $j, 'From:' ), 'From preserved' );
+$GLOBALS['cv_opts'] = array( 'disable_actions_cv-test-123' => 'true' );
+cv_ok( false === $h->checkview_disable_form_actions( true ), 'addons disabled when flagged' );
+
+cv_finish();

--- a/tests/harness/cases/forminator_shutdown_diag.php
+++ b/tests/harness/cases/forminator_shutdown_diag.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Verification for the Forminator shutdown diagnostic and the Forminator
+ * form-list key rename.
+ *
+ * Drives the REAL checkview_log_unfinished_submission() through every state, and
+ * asserts the premises it rests on against WordPress's own source.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+cv_need_wordpress();
+cv_need_change( 'includes/formhelpers/class-checkview-forminator-helper.php', 'checkview_log_unfinished_submission', 'PR #238' );
+
+$HELPER = CV_PLUGIN_DIR . '/includes/formhelpers/class-checkview-forminator-helper.php';
+$API    = CV_PLUGIN_DIR . '/includes/API/class-checkview-api.php';
+$WPROOT = CV_WP . '/';
+
+
+$GLOBALS['cv_log'] = array();
+class Checkview_Admin_Logs {
+	public static function add( $c, $m ) { $GLOBALS['cv_log'][] = $m; }
+}
+function sanitize_text_field( $v ) { return is_string( $v ) ? trim( strip_tags( $v ) ) : ''; }
+function wp_unslash( $v ) { return $v; }
+
+echo "\n=== the premise: shutdown fires even when a request die()s ===\n";
+$settings = file_get_contents( $WPROOT . 'wp-settings.php' );
+$load     = file_get_contents( $WPROOT . 'wp-includes/load.php' );
+cv_ok(
+	(bool) preg_match( "/register_shutdown_function\(\s*'shutdown_action_hook'\s*\)/", $settings ),
+	'WordPress registers shutdown_action_hook via register_shutdown_function (wp-settings.php)'
+);
+cv_ok(
+	(bool) preg_match( "/function shutdown_action_hook\(\)\s*\{\s*.*?do_action\(\s*'shutdown'\s*\)/s", $load ),
+	"and that handler is what fires do_action('shutdown') (load.php)"
+);
+// register_shutdown_function survives die()/exit, which is how admin-ajax ends.
+$ajax = file_get_contents( $WPROOT . 'wp-admin/admin-ajax.php' );
+cv_ok( false !== strpos( $ajax, 'wp_die(' ), 'admin-ajax terminates via wp_die(), which register_shutdown_function still covers' );
+
+echo "\n=== extract the real diagnostic method ===\n";
+$src = file_get_contents( $HELPER );
+cv_ok(
+	(bool) preg_match( '/public function checkview_log_unfinished_submission\(\) \{.*?\n\t\t\}/s', $src, $m ),
+	'extracted checkview_log_unfinished_submission() from the shipped file'
+);
+
+// Wrap the real method in a minimal class carrying the same two flags.
+eval(
+	'class Diag {
+		public $handler_ran = false;
+		public $submission_reached_save = false;
+		' . $m[0] . '
+	}'
+);
+
+/** Runs the real method for one state and returns what it logged. */
+function run( bool $handler_ran, bool $reached_save, ?string $action ): array {
+	$GLOBALS['cv_log'] = array();
+	$_POST             = ( null === $action ) ? array() : array( 'action' => $action );
+	$d                 = new Diag();
+	$d->handler_ran             = $handler_ran;
+	$d->submission_reached_save = $reached_save;
+	$d->checkview_log_unfinished_submission();
+	return $GLOBALS['cv_log'];
+}
+
+$AJAX_ACTION = 'forminator_submit_form_custom-forms';
+
+echo "\n=== the happy path stays silent ===\n";
+cv_ok( array() === run( true, true, $AJAX_ACTION ), 'handler ran -> logs nothing' );
+
+echo "\n=== the two failures it exists to tell apart ===\n";
+$rejected = run( false, false, $AJAX_ACTION );
+cv_ok( 1 === count( $rejected ), 'rejected-before-save logs exactly one line' );
+cv_ok( false !== strpos( $rejected[0], 'before an entry was saved' ), '  ...and says the entry was never saved' );
+cv_ok( false !== strpos( $rejected[0], 'honeypot' ), '  ...names honeypot/spam/captcha as the cause' );
+cv_ok( false !== strpos( $rejected[0], 'NOT a missing-hook problem' ), '  ...and explicitly rules out the other cause' );
+
+$hookless = run( false, true, $AJAX_ACTION );
+cv_ok( 1 === count( $hookless ), 'saved-but-no-hook logs exactly one line' );
+cv_ok( false !== strpos( $hookless[0], 'saved an entry' ), '  ...and says the entry WAS saved' );
+cv_ok( false !== strpos( $hookless[0], 'forminator_form_after_save_entry' ), '  ...names the hooks that failed to fire' );
+cv_ok( false !== strpos( $hookless[0], 'NOT a spam or honeypot rejection' ), '  ...and explicitly rules out the other cause' );
+
+// The whole point is that these are distinguishable in ip-logs.
+cv_ok( $rejected[0] !== $hookless[0], 'the two messages are different text, not one generic line' );
+
+echo "\n=== it stays out of unrelated requests ===\n";
+cv_ok( array() === run( false, false, null ), 'no action in POST -> silent' );
+cv_ok( array() === run( false, false, 'wpforms_submit' ), "another plugin's submit -> silent" );
+cv_ok( array() === run( false, true, 'heartbeat' ), 'an ordinary admin-ajax heartbeat -> silent' );
+cv_ok( array() === run( false, false, 'forminator_something_else' ), 'a non-submit Forminator ajax action -> silent' );
+
+echo "\n=== both Forminator submit paths are covered by the one marker ===\n";
+cv_ok( 1 === count( run( false, false, 'forminator_submit_form_custom-forms' ) ), 'ajax custom-forms submit is matched' );
+cv_ok( 1 === count( run( false, false, 'forminator_submit_form_' ) ), 'the marker is matched by prefix, so other entry types are too' );
+
+echo "\n=== registration ===\n";
+cv_ok(
+	(bool) preg_match( "/add_action\(\s*'shutdown',\s*array\(\s*\\\$this,\s*'checkview_log_unfinished_submission',\s*\),\s*0\s*\)/s", $src ),
+	'registered on shutdown at priority 0'
+);
+cv_ok(
+	(bool) preg_match( '/\$this->submission_reached_save = true;/', $src ),
+	'the pre-save hook sets submission_reached_save'
+);
+cv_ok(
+	(bool) preg_match( '/\$this->handler_ran\s*=\s*true;/', $src ),
+	'the post-save handler sets handler_ran'
+);
+
+echo "\n=== the form-list key rename (#231) ===\n";
+$api = file_get_contents( $API );
+cv_ok( 0 === substr_count( $api, "ForminatorForms" ), 'no ForminatorForms key remains' );
+cv_ok( 3 === substr_count( $api, "\$forms['Forminator']" ), "all three sites emit \$forms['Forminator'] (got " . substr_count( $api, "\$forms['Forminator']" ) . ')' );
+cv_ok( 'forminator' === strtolower( 'Forminator' ), "and it lowercases to 'forminator', which the SaaS pluginId expects" );
+
+cv_finish();

--- a/tests/harness/cases/gf_plural_quoted.php
+++ b/tests/harness/cases/gf_plural_quoted.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Verification for the Gravity Forms plural-tag and single-quote patterns.
+ *
+ * The pattern-building block is EXTRACTED FROM THE SHIPPED FILE and executed, so
+ * the assertions run against the real construction rather than a copy of it.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+cv_need_wordpress();
+cv_need_change( 'includes/API/class-checkview-api.php', 'gf_patterns', 'PR #246' );
+
+$API = CV_PLUGIN_DIR . '/includes/API/class-checkview-api.php';
+$WP  = CV_WP . '/wp-includes/shortcodes.php';
+
+
+
+echo "\n=== WordPress itself treats all three quoting forms alike ===\n";
+require_once $WP;
+$parsed = array();
+foreach ( array( 'id="7"', "id='7'", 'id=7' ) as $t ) {
+	$a = shortcode_parse_atts( $t );
+	$parsed[ $t ] = $a['id'] ?? null;
+}
+cv_ok( '7' === $parsed['id="7"'], 'double-quoted id parses to 7' );
+cv_ok( '7' === $parsed["id='7'"], "single-quoted id parses to 7 — so it is a working embed" );
+cv_ok( '7' === $parsed['id=7'], 'unquoted id parses to 7' );
+
+echo "\n=== run the shipped pattern construction ===\n";
+$api = file_get_contents( $API );
+preg_match( '/(\$gf_patterns = array\(.*?\n\t\t\t\t\t\})/s', $api, $m );
+cv_ok( ! empty( $m[1] ), 'extracted the pattern-building block from the shipped file' );
+
+$row = (object) array( 'id' => 7 );
+eval( $m[1] );
+
+cv_ok( 9 === count( $gf_patterns ), 'builds 9 patterns: 1 block + 4 per spelling (got ' . count( $gf_patterns ) . ')' );
+cv_ok( count( $gf_patterns ) === count( array_unique( $gf_patterns ) ), 'no duplicate patterns' );
+
+// The placeholder count must equal the pattern count or prepare() misbinds.
+preg_match( '/(\$gf_where = implode\(.*?\);)/s', $api, $wm );
+cv_ok( ! empty( $wm[1] ), 'extracted the WHERE construction' );
+eval( $wm[1] );
+cv_ok(
+	substr_count( $gf_where, '%s' ) === count( $gf_patterns ),
+	'placeholder count matches pattern count (' . substr_count( $gf_where, '%s' ) . ' vs ' . count( $gf_patterns ) . ')'
+);
+
+$matches = function ( string $content ) use ( $gf_patterns ): bool {
+	foreach ( $gf_patterns as $p ) {
+		if ( cv_like( $p, $content ) ) { return true; }
+	}
+	return false;
+};
+
+echo "\n=== finds every working embed of form 7 ===\n";
+$should_find = array(
+	'[gravityform id="7" title="false"]'   => 'singular, double-quoted',
+	"[gravityform id='7' title='false']"   => 'singular, single-quoted',
+	'[gravityform id=7]'                   => 'singular, unquoted, terminated',
+	'[gravityform id=7 title="false"]'     => 'singular, unquoted, more attributes',
+	'[gravityforms id="7" title="false"]'  => 'PLURAL, double-quoted',
+	"[gravityforms id='7']"                => 'PLURAL, single-quoted',
+	'[gravityforms id=7]'                  => 'PLURAL, unquoted, terminated',
+	'[gravityforms id=7 ajax="true"]'      => 'PLURAL, unquoted, more attributes',
+	'<!-- wp:gravityforms/form {"formId":"7"} /-->' => 'block editor',
+);
+foreach ( $should_find as $content => $label ) {
+	cv_ok( $matches( $content ), "finds: $label" );
+}
+
+echo "\n=== does not steal another form's pages ===\n";
+$should_not = array(
+	'[gravityform id=77]'      => 'id=77',
+	'[gravityform id=7123]'    => 'id=7123',
+	'[gravityforms id=70]'     => 'plural id=70',
+	'[gravityform id="77"]'    => 'quoted id=77',
+	"[gravityforms id='77']"   => 'plural single-quoted id=77',
+	'<!-- wp:gravityforms/form {"formId":"77"} /-->' => 'block formId 77',
+);
+foreach ( $should_not as $content => $label ) {
+	cv_ok( ! $matches( $content ), "excludes: $label" );
+}
+
+echo "\n=== the two spellings stay disjoint ===\n";
+$sing = array_values( array_filter( $gf_patterns, fn( $p ) => false !== strpos( $p, '[gravityform id' ) ) );
+$plur = array_values( array_filter( $gf_patterns, fn( $p ) => false !== strpos( $p, '[gravityforms id' ) ) );
+cv_ok( 4 === count( $sing ), 'four singular patterns (got ' . count( $sing ) . ')' );
+cv_ok( 4 === count( $plur ), 'four plural patterns (got ' . count( $plur ) . ')' );
+$sing_hits_plural = false;
+foreach ( $sing as $p ) {
+	if ( cv_like( $p, '[gravityforms id=7]' ) || cv_like( $p, '[gravityforms id="7"]' ) ) { $sing_hits_plural = true; }
+}
+cv_ok( ! $sing_hits_plural, 'singular patterns do not match plural content (the `s` blocks them)' );
+
+cv_finish();

--- a/tests/harness/cases/wp_armour_cf7_wpforms_elementor.php
+++ b/tests/harness/cases/wp_armour_cf7_wpforms_elementor.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Verification for the WP Armour unhooks in the CF7, WPForms and Elementor helpers.
+ *
+ * Both sides are read from the shipped files: WP Armour's own registration from
+ * honeypot/includes/integration/*.php, and the helper's removal from the plugin
+ * source. If either drifts — WP Armour changes a priority, or someone edits the
+ * helper — the correspondence assertions fail rather than silently no-opping.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+cv_need_fixture( 'honeypot' );
+cv_need_change( 'includes/formhelpers/class-checkview-cf7-helper.php', 'checkview_unhook_wp_armour', 'PR #242' );
+
+$HELPER = CV_PLUGIN_DIR . '/includes/formhelpers/';
+$ARMOUR = CV_FIXTURES . '/honeypot/includes/integration/';
+
+$GLOBALS['cv_log']   = array();
+$GLOBALS['wp_hooks'] = array();
+
+function _id( $cb ) {
+	if ( is_array( $cb ) ) {
+		return ( is_object( $cb[0] ) ? spl_object_hash( $cb[0] ) : (string) $cb[0] ) . '::' . $cb[1];
+	}
+	return is_object( $cb ) ? spl_object_hash( $cb ) : (string) $cb;
+}
+function add_action( $tag, $cb, $priority = 10, $args = 1 ) {
+	$GLOBALS['wp_hooks'][ $tag ][ $priority ][ _id( $cb ) ] = $cb;
+}
+function add_filter( $tag, $cb, $priority = 10, $args = 1 ) { add_action( $tag, $cb, $priority, $args ); }
+function remove_action( $tag, $cb, $priority = 10 ) {
+	$id = _id( $cb );
+	if ( isset( $GLOBALS['wp_hooks'][ $tag ][ $priority ][ $id ] ) ) {
+		unset( $GLOBALS['wp_hooks'][ $tag ][ $priority ][ $id ] );
+		return true;
+	}
+	return false;
+}
+function remove_filter( $tag, $cb, $priority = 10 ) { return remove_action( $tag, $cb, $priority ); }
+function has_action( $tag, $cb ) {
+	foreach ( $GLOBALS['wp_hooks'][ $tag ] ?? array() as $p => $cbs ) {
+		if ( isset( $cbs[ _id( $cb ) ] ) ) { return $p; }
+	}
+	return false;
+}
+
+class Checkview_Admin_Logs {
+	public static function add( $c, $m ) { $GLOBALS['cv_log'][] = $m; }
+}
+
+
+/** WP Armour's real registration for one integration file. */
+function armour_registration( string $file ): ?array {
+	$src = @file_get_contents( $file );
+	if ( false === $src ) { return null; }
+	if ( ! preg_match( "/add_(?:filter|action)\(\s*'([^']+)'\s*,\s*'(wpa[a-z0-9_]+)'\s*(?:,\s*(\d+))?/i", $src, $m ) ) {
+		return null;
+	}
+	return array( 'tag' => $m[1], 'cb' => $m[2], 'priority' => isset( $m[3] ) ? (int) $m[3] : 10 );
+}
+
+/** The helper's real removal, extracted from the shipped file. */
+function helper_removal( string $file ): ?array {
+	$src = @file_get_contents( $file );
+	if ( false === $src ) { return null; }
+	if ( ! preg_match( "/remove_(?:filter|action)\(\s*'([^']+)'\s*,\s*'(wpa[a-z0-9_]+)'\s*,\s*(\d+)\s*\)/i", $src, $m ) ) {
+		return null;
+	}
+	return array( 'tag' => $m[1], 'cb' => $m[2], 'priority' => (int) $m[3] );
+}
+
+/** Extracts the real unhook method and evals it as a standalone function. */
+function load_unhook( string $file, string $as ): bool {
+	$src = @file_get_contents( $file );
+	if ( false === $src ) { return false; }
+	if ( ! preg_match( '/public function checkview_unhook_wp_armour\(\) \{.*?\n\t\t\}/s', $src, $m ) ) {
+		return false;
+	}
+	$fn = preg_replace(
+		'/public function checkview_unhook_wp_armour\(\)/',
+		'function ' . $as . '()',
+		$m[0],
+		1
+	);
+	eval( $fn );
+	return true;
+}
+
+$cases = array(
+	'cf7'       => array( 'helper' => 'class-checkview-cf7-helper.php',       'armour' => 'wpa_contactform7.php' ),
+	'wpforms'   => array( 'helper' => 'class-checkview-wpforms-helper.php',   'armour' => 'wpa_wpforms.php' ),
+	'elementor' => array( 'helper' => 'class-checkview-elementor-helper.php', 'armour' => 'wpa_elementor.php' ),
+);
+
+foreach ( $cases as $slug => $c ) {
+	echo "\n=== $slug ===\n";
+	$hfile = $HELPER . $c['helper'];
+	$reg   = armour_registration( $ARMOUR . $c['armour'] );
+	$rem   = helper_removal( $hfile );
+
+	cv_ok( null !== $reg, "read WP Armour's own registration from {$c['armour']}" );
+	cv_ok( null !== $rem, "read the helper's removal from {$c['helper']}" );
+	if ( null === $reg || null === $rem ) { continue; }
+
+	// Drift guards: the helper must target exactly what WP Armour registers.
+	cv_ok( $rem['tag'] === $reg['tag'], "hook tag matches WP Armour ({$reg['tag']})" );
+	cv_ok( $rem['cb'] === $reg['cb'], "callback matches WP Armour ({$reg['cb']})" );
+	cv_ok(
+		$rem['priority'] === $reg['priority'],
+		"priority matches WP Armour ({$reg['priority']}) — remove_* is a no-op otherwise"
+	);
+
+	// The unhook must be registered on init at PHP_INT_MAX.
+	$hsrc = file_get_contents( $hfile );
+	cv_ok(
+		(bool) preg_match(
+			"/add_action\(\s*'init',\s*array\(\s*\\\$this,\s*'checkview_unhook_wp_armour'\s*\),\s*PHP_INT_MAX\s*\)/s",
+			$hsrc
+		),
+		'registered on init at PHP_INT_MAX (after WP Armour loads its integrations)'
+	);
+
+	cv_ok( load_unhook( $hfile, 'cv_unhook_' . $slug ), 'extracted the real unhook method' );
+
+	// Present: WP Armour registered exactly as it does in its own source.
+	$GLOBALS['wp_hooks'] = array();
+	$GLOBALS['cv_log']   = array();
+	add_filter( $reg['tag'], $reg['cb'], $reg['priority'] );
+	cv_ok( false !== has_action( $reg['tag'], $reg['cb'] ), 'precondition: WP Armour is hooked' );
+
+	call_user_func( 'cv_unhook_' . $slug );
+	cv_ok( false === has_action( $reg['tag'], $reg['cb'] ), 'WP Armour is unhooked' );
+	cv_ok(
+		1 === count( array_filter( $GLOBALS['cv_log'], fn( $l ) => false !== strpos( $l, 'Unhooked WP Armour' ) ) ),
+		'logged the removal exactly once'
+	);
+
+	// Absent: no plugin, no function — must be a silent no-op, not a warning.
+	$GLOBALS['wp_hooks'] = array();
+	$GLOBALS['cv_log']   = array();
+	call_user_func( 'cv_unhook_' . $slug );
+	cv_ok( array() === $GLOBALS['cv_log'], 'WP Armour absent -> silent no-op' );
+
+	// Present but moved: the function exists yet the priority changed, so the
+	// removal fails. That must be surfaced, not swallowed.
+	$GLOBALS['wp_hooks'] = array();
+	$GLOBALS['cv_log']   = array();
+	eval( 'if ( ! function_exists( "' . $reg['cb'] . '" ) ) { function ' . $reg['cb'] . '() {} }' );
+	add_filter( $reg['tag'], $reg['cb'], $reg['priority'] + 5 );
+	call_user_func( 'cv_unhook_' . $slug );
+	cv_ok(
+		1 === count( array_filter( $GLOBALS['cv_log'], fn( $l ) => false !== strpos( $l, 'not removable' ) ) ),
+		'priority drift is logged as still-at-risk rather than silently ignored'
+	);
+	cv_ok( false !== has_action( $reg['tag'], $reg['cb'] ), 'and the callback is honestly still hooked' );
+}
+
+cv_finish();

--- a/tests/harness/cases/wp_armour_gf_fluent.php
+++ b/tests/harness/cases/wp_armour_gf_fluent.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Verification for the WP Armour unhooks in the GF and Fluent helpers.
+ *
+ * Drives the REAL methods against an emulation of remove_action/has_action, and
+ * reproduces WP Armour's own registration from
+ * honeypot/includes/integration/wpa_{gravityforms,fluentform}.php.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+cv_need_fixture( 'honeypot' );
+cv_need_change( 'includes/formhelpers/class-checkview-gforms-helper.php', 'checkview_unhook_wp_armour', 'PR #240' );
+
+define( 'WPINC', 1 );
+define( 'TEST_EMAIL', 'test@test-mail.checkview.io' );
+
+$GLOBALS['cv_log']    = array();
+$GLOBALS['wp_hooks']  = array();
+
+function add_action( $tag, $cb, $priority = 10, $args = 1 ) {
+	$GLOBALS['wp_hooks'][ $tag ][ $priority ][ _id( $cb ) ] = $cb;
+}
+function add_filter( $tag, $cb, $priority = 10, $args = 1 ) { add_action( $tag, $cb, $priority, $args ); }
+function _id( $cb ) {
+	if ( is_array( $cb ) ) {
+		return ( is_object( $cb[0] ) ? spl_object_hash( $cb[0] ) : (string) $cb[0] ) . '::' . $cb[1];
+	}
+	if ( is_object( $cb ) ) {        // closures, as WP does
+		return spl_object_hash( $cb );
+	}
+	return (string) $cb;
+}
+function remove_action( $tag, $cb, $priority = 10 ) {
+	$id = _id( $cb );
+	if ( isset( $GLOBALS['wp_hooks'][ $tag ][ $priority ][ $id ] ) ) {
+		unset( $GLOBALS['wp_hooks'][ $tag ][ $priority ][ $id ] );
+		return true;
+	}
+	return false;
+}
+function remove_filter( $tag, $cb, $priority = 10 ) { return remove_action( $tag, $cb, $priority ); }
+function has_action( $tag, $cb ) {
+	foreach ( $GLOBALS['wp_hooks'][ $tag ] ?? array() as $p => $cbs ) {
+		if ( isset( $cbs[ _id( $cb ) ] ) ) { return $p; }
+	}
+	return false;
+}
+function apply_filters( $t, $v ) { return $v; }
+function __return_false() { return false; }
+function __return_true() { return true; }
+function __return_null() { return null; }
+function __return_empty_string() { return ''; }
+function get_option( $k, $d = false ) { return $d; }
+function wp_json_encode( $v ) { return json_encode( $v ); }
+function get_checkview_test_id() { return 'cv-test-123'; }
+function complete_checkview_test( $id ) {}
+function checkview_truncate_meta_key( $k ) { return $k; }
+function checkview_truncate_for_cv_entry( $r ) { return $r; }
+function checkview_ff_should_defer_delete() { return true; }
+function checkview_gf_should_defer_delete() { return true; }
+function current_time( $t ) { return '2026-01-01 00:00:00'; }
+function sanitize_url( $u ) { return $u; }
+function wp_unslash( $v ) { return $v; }
+function maybe_serialize( $v ) { return is_array( $v ) ? serialize( $v ) : $v; }
+function maybe_unserialize( $v ) { return $v; }
+function esc_html__( $s, $d = '' ) { return $s; }
+function rgar( $a, $k ) { return $a[ $k ] ?? ''; }
+function cv_should_allow_original_recipients() { return false; }
+function cv_append_test_email_array( $r ) { return (array) $r; }
+function cv_append_test_email_string( $r ) { return (string) $r; }
+function cv_inject_reply_to_header( $h ) { return $h; }
+
+class Checkview_Loader {}
+class Checkview_Admin_Logs {
+	public static function add( $c, $m ) { $GLOBALS['cv_log'][] = $m; }
+}
+
+
+$base = CV_PLUGIN_DIR . '/includes/formhelpers/';
+
+// ---------------------------------------------------------------- GRAVITY FORMS
+echo "\n=== Gravity Forms ===\n";
+$GLOBALS['wp_hooks'] = array();
+require_once $base . 'class-checkview-gforms-helper.php';
+$gf = ( new ReflectionClass( 'Checkview_Gforms_Helper' ) )->newInstanceWithoutConstructor();
+
+cv_ok( method_exists( $gf, 'checkview_unhook_wp_armour' ), 'GF helper exposes the unhook' );
+
+// WP Armour's own registration (wpa_gravityforms.php:6).
+function wpa_gravityforms_extra_validation( $validation_result ) {
+	$validation_result['is_valid'] = false;
+	return $validation_result;
+}
+add_action( 'gform_validation', 'wpa_gravityforms_extra_validation' );
+// CheckView's own bypass sits on the same hook and must survive.
+add_filter( 'gform_validation', array( $gf, 'checkview_bypass_captcha_validation' ), PHP_INT_MAX );
+
+cv_ok( 10 === has_action( 'gform_validation', 'wpa_gravityforms_extra_validation' ), 'precondition: WP Armour at priority 10' );
+
+$GLOBALS['cv_log'] = array();
+$gf->checkview_unhook_wp_armour();
+
+cv_ok( false === has_action( 'gform_validation', 'wpa_gravityforms_extra_validation' ), "WP Armour's GF callback removed" );
+cv_ok( PHP_INT_MAX === has_action( 'gform_validation', array( $gf, 'checkview_bypass_captcha_validation' ) ), "CheckView's own gform_validation bypass NOT removed" );
+cv_ok( false !== strpos( implode( ' | ', $GLOBALS['cv_log'] ), 'Unhooked WP Armour' ), 'logs the removal' );
+
+$GLOBALS['cv_log'] = array();
+$gf->checkview_unhook_wp_armour();
+cv_ok( false !== strpos( implode( ' | ', $GLOBALS['cv_log'] ), 'not removable' ), 'second run reports drift (function present, nothing hooked)' );
+
+echo "\n-- why a marker fallback would NOT have worked --\n";
+// The failure lands on an arbitrary field with an operator-configurable message.
+$markers = array( 'captcha', 'recaptcha', 'are you human', 'looks like spam' );
+$wpa_msg = strtolower( ' Spamming or your Javascript is disabled !!' );
+$hit = false;
+foreach ( $markers as $mk ) { if ( false !== strpos( $wpa_msg, $mk ) ) { $hit = true; } }
+cv_ok( ! $hit, "WP Armour's default message matches none of the anti-bot markers" );
+
+// ---------------------------------------------------------------- FLUENT FORMS
+echo "\n=== Fluent Forms ===\n";
+$GLOBALS['wp_hooks'] = array();
+require_once $base . 'class-checkview-fluent-forms-helper.php';
+$ff = ( new ReflectionClass( 'Checkview_Fluent_Forms_Helper' ) )->newInstanceWithoutConstructor();
+
+cv_ok( method_exists( $ff, 'checkview_unhook_wp_armour' ), 'Fluent helper exposes the unhook' );
+
+function wpa_fluent_form_extra_validation( $insertData, $data, $form ) {}
+add_action( 'fluentform/before_insert_submission', 'wpa_fluent_form_extra_validation', 10, 3 );
+add_action( 'fluentform_before_insert_submission', 'wpa_fluent_form_extra_validation', 10, 3 );
+// A Fluent core callback on the same hook must survive.
+$core = new class { public function insert() {} };
+add_action( 'fluentform/before_insert_submission', array( $core, 'insert' ), 20 );
+
+$GLOBALS['cv_log'] = array();
+$ff->checkview_unhook_wp_armour();
+
+cv_ok( false === has_action( 'fluentform/before_insert_submission', 'wpa_fluent_form_extra_validation' ), 'slash-style hook cleared' );
+cv_ok( false === has_action( 'fluentform_before_insert_submission', 'wpa_fluent_form_extra_validation' ), 'legacy underscore hook cleared too' );
+cv_ok( 20 === has_action( 'fluentform/before_insert_submission', array( $core, 'insert' ) ), "Fluent's own callback on the same hook untouched" );
+cv_ok( false !== strpos( implode( ' | ', $GLOBALS['cv_log'] ), 'Unhooked WP Armour from [2]' ), 'logs both removals' );
+
+$GLOBALS['cv_log'] = array();
+$ff->checkview_unhook_wp_armour();
+cv_ok( false !== strpos( implode( ' | ', $GLOBALS['cv_log'] ), 'not removable' ), 'second run reports drift' );
+
+echo "\n-- why nothing but an unhook could work here --\n";
+$src = file_get_contents( '/private/tmp/claude-501/-Users-schwartzen-Local-Sites-checkview-helper-helper/c4849e8e-5036-4b73-99c9-57d3cd37be5f/scratchpad/honeypot/includes/integration/wpa_fluentform.php' );
+cv_ok( false !== strpos( $src, 'wp_send_json_error' ) && false !== strpos( $src, 'wp_die' ), 'WP Armour terminates the request rather than returning a verdict' );
+
+echo "\n=== absent plugin is silent ===\n";
+$GLOBALS['wp_hooks'] = array();
+$GLOBALS['cv_log']   = array();
+// Functions still exist in this process, so the drift branch is expected here;
+// what matters is that nothing fatals and no hook is touched.
+$gf->checkview_unhook_wp_armour();
+$ff->checkview_unhook_wp_armour();
+cv_ok( array() === ( $GLOBALS['wp_hooks'] ?? array() ), 'no hooks were added or mutated' );
+
+cv_finish();

--- a/tests/harness/fetch-fixtures.sh
+++ b/tests/harness/fetch-fixtures.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Downloads the third-party sources the verification cases assert against.
+#
+# These are NOT committed: they are large, they are not ours, and pinning a copy
+# in the repo would defeat the point. Several cases exist specifically to notice
+# when one of these plugins changes a hook name, a priority or a default — so
+# they must read whatever version is actually current.
+#
+# Usage:  tests/harness/fetch-fixtures.sh [--wordpress]
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES="${HERE}/fixtures"
+PLUGIN_ROOT="$(cd "${HERE}/../.." && pwd)"
+
+mkdir -p "${FIXTURES}"
+
+# Slugs as published on wordpress.org. Forminator is the free build; Pro is out
+# of scope. Gravity Forms is intentionally absent — it is commercial and not
+# downloadable here, so the GF cases assert against WordPress core's shortcode
+# parser and the plugin's own source instead.
+PLUGINS=(
+  contact-form-7
+  formidable
+  forminator
+  honeypot                 # WP Armour
+  cleantalk-spam-protect
+)
+
+for slug in "${PLUGINS[@]}"; do
+  if [ -d "${FIXTURES}/${slug}" ]; then
+    echo "  ${slug} — already present, skipping"
+    continue
+  fi
+  echo "  ${slug} — downloading"
+  curl -fsSL "https://downloads.wordpress.org/plugin/${slug}.latest-stable.zip" -o "${FIXTURES}/${slug}.zip"
+  unzip -q -o "${FIXTURES}/${slug}.zip" -d "${FIXTURES}"
+  rm -f "${FIXTURES}/${slug}.zip"
+done
+
+# A couple of cases assert against WordPress core itself — that shortcode
+# parsing accepts single quotes, and that `shutdown` still fires after the die()
+# ending an admin-ajax request. Opt-in because it is a large download and most
+# cases do not need it.
+if [ "${1:-}" = "--wordpress" ]; then
+  if [ -d "${PLUGIN_ROOT}/wordpress" ]; then
+    echo "  wordpress — already present, skipping"
+  else
+    echo "  wordpress — downloading"
+    curl -fsSL "https://wordpress.org/latest.zip" -o "${FIXTURES}/wordpress.zip"
+    unzip -q -o "${FIXTURES}/wordpress.zip" -d "${PLUGIN_ROOT}"
+    rm -f "${FIXTURES}/wordpress.zip"
+  fi
+fi
+
+echo
+echo "Fixtures ready in ${FIXTURES}"
+echo "Run: php tests/harness/run.php"

--- a/tests/harness/run.php
+++ b/tests/harness/run.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Runs every verification case and reports one tally.
+ *
+ * Usage:
+ *   php tests/harness/run.php            # all cases
+ *   php tests/harness/run.php formidable # only cases whose name matches
+ *
+ * Each case runs in its own process, so cases are free to redeclare the same
+ * WordPress stubs without colliding.
+ *
+ * Exit code is 1 if any assertion failed. Skips do NOT fail the run — a fixture
+ * may be absent, or a case may target a branch that is not merged yet — but they
+ * are always listed, so a green run can never hide an unrun case.
+ *
+ * @package Checkview
+ * @subpackage Checkview/tests/harness
+ */
+
+/** Must match CV_EXIT_SKIP in bootstrap.php. */
+define( 'CV_RUNNER_SKIP', 2 );
+
+$filter = $argv[1] ?? '';
+$cases  = glob( __DIR__ . '/cases/*.php' );
+sort( $cases );
+
+if ( '' !== $filter ) {
+	$cases = array_values(
+		array_filter(
+			$cases,
+			static function ( $case ) use ( $filter ) {
+				return false !== strpos( basename( $case ), $filter );
+			}
+		)
+	);
+}
+
+if ( empty( $cases ) ) {
+	fwrite( STDERR, "No cases matched.\n" );
+	exit( 1 );
+}
+
+$total_asserts = 0;
+$total_fails   = 0;
+$ran            = 0;
+$skipped        = array();
+$failed_cases   = array();
+$php            = PHP_BINARY;
+
+foreach ( $cases as $case ) {
+	$name = basename( $case, '.php' );
+
+	$output   = array();
+	$exit_code = 0;
+	exec( escapeshellarg( $php ) . ' ' . escapeshellarg( $case ) . ' 2>&1', $output, $exit_code );
+	$text = implode( "\n", $output );
+
+	if ( CV_RUNNER_SKIP === $exit_code ) {
+		$reason = '';
+		if ( preg_match( '/^SKIP: (.+)$/m', $text, $m ) ) {
+			$reason = $m[1];
+		}
+		$skipped[] = array( $name, $reason );
+		printf( "  %-46s SKIP  %s\n", $name, $reason );
+		continue;
+	}
+
+	$asserts = 0;
+	$fails   = 0;
+	if ( preg_match( '/^(\d+) assertions, (\d+) failed$/m', $text, $m ) ) {
+		$asserts = (int) $m[1];
+		$fails   = (int) $m[2];
+	} else {
+		// No tally line means the case died before finishing — a hard error, not
+		// a skip. Surface the output rather than silently counting zero.
+		echo "  {$name}  DID NOT COMPLETE\n";
+		echo preg_replace( '/^/m', '      ', $text ) . "\n";
+		$failed_cases[] = $name;
+		$total_fails   += 1;
+		continue;
+	}
+
+	++$ran;
+	$total_asserts += $asserts;
+	$total_fails   += $fails;
+
+	if ( $fails > 0 ) {
+		$failed_cases[] = $name;
+		printf( "  %-46s %d assertions, %d FAILED\n", $name, $asserts, $fails );
+		foreach ( preg_grep( '/^\s+FAIL: /', $output ) as $line ) {
+			echo "    {$line}\n";
+		}
+		continue;
+	}
+
+	printf( "  %-46s %d assertions, ok\n", $name, $asserts );
+}
+
+echo "\n";
+echo str_repeat( '-', 72 ) . "\n";
+printf( "%d cases run, %d skipped — %d assertions, %d failed\n", $ran, count( $skipped ), $total_asserts, $total_fails );
+
+if ( ! empty( $skipped ) ) {
+	echo "\nSkipped:\n";
+	foreach ( $skipped as $skip ) {
+		printf( "  %-46s %s\n", $skip[0], $skip[1] );
+	}
+}
+
+if ( ! empty( $failed_cases ) ) {
+	echo "\nFailed: " . implode( ', ', $failed_cases ) . "\n";
+	exit( 1 );
+}
+
+exit( 0 );


### PR DESCRIPTION
Every fix in the current backlog was verified by a standalone assertion script,
and none of those scripts were in the repo. They lived in a scratch directory,
which meant no reviewer could reproduce any of it and the checks were lost
between sessions. This commits them.

Nothing here needs a provisioned WordPress. The PHPUnit suite in tests/ cannot
bootstrap from an ordinary checkout, which is what pushed this work out of the
repo in the first place; these cases need only `php`, and stub the handful of
WordPress functions each one touches before calling the plugin's real methods.

  tests/harness/fetch-fixtures.sh
  php tests/harness/run.php

Most cases are not testing our logic in isolation. They pin our ASSUMPTIONS
ABOUT OTHER PEOPLE'S CODE, which is where nearly every bug in this backlog
actually came from: a hook name built by concatenation so grepping the literal
finds nothing; a priority remove_action() has to match exactly; a default value
one call deeper than the file being read; an undocumented shortcode alias; an
upstream WHERE clause we had reimplemented slightly differently. So they read the
shipped third-party source and assert the correspondence. If WP Armour moves a
priority or CleanTalk changes what its sentinel returns, the case fails instead
of the bypass silently becoming a no-op.

Where a case can execute rather than pattern-match, it does: formidable_form_list
runs the extracted WHERE clause against a real SQLite table of the row shapes
Formidable produces; gf_plural_quoted runs WordPress's own shortcode parser.

Fixtures are downloaded, not committed, and are git-ignored. Pinning copies would
defeat the point — the cases exist to notice when those plugins change, so they
have to read what is current. Gravity Forms is not fetchable, so its cases assert
against WP core and our own source instead.

Skips are never counted as passes. A case skips when a fixture is absent, or when
the change it covers is not in the tree yet — and then it names the PR. On
development today all 11 skip and report what they are waiting for; each starts
running by itself as its PR merges. run.php lists skips separately, so a run that
verified nothing cannot be mistaken for a run that verified everything.

11 cases, 260 assertions once the backlog is merged.

---

## Reviewing this

```bash
tests/harness/fetch-fixtures.sh --wordpress
php tests/harness/run.php
```

On `development` today that prints **0 cases run, 11 skipped**, each naming the PR it is waiting for. That is the honest result — none of the fixes are merged yet.

Against a tree with all 24 PRs merged it prints **11 cases run, 0 skipped — 260 assertions, 0 failed**.

I confirmed it actually fails rather than being vacuously green: changing one `remove_filter()` priority from 10 to 11 in the CF7 helper fails 3 assertions and exits non-zero.

## Independent of everything else

Touches no plugin code — only `tests/harness/`, plus one line each in `.gitignore` and `.distignore`. Mergeable at any point in the sequence, and most useful merged **early**, since it then verifies each subsequent merge.

Assigned to @grayson-inspry alongside the rest.