### PR TITLE
fix(gforms): stop 500 when Zero Spam fires gf_zero_spam_check_key_field

### DIFF
--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -772,7 +772,7 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		 * Variadic on purpose: Zero Spam fires this filter with a varying
 		 * number of arguments. `gf_apply_filters()` passes 3 (value, form,
 		 * entry) because the form-id modifier is consumed by GF itself, while
-		 * two call sites use a plain `apply_filters()` that passes only 2. A
+		 * three call sites use a plain `apply_filters()` that passes only 2. A
 		 * fixed 4-parameter signature therefore threw an uncaught
 		 * ArgumentCountError and 500'd the whole page render.
 		 *

--- a/includes/formhelpers/class-checkview-gforms-helper.php
+++ b/includes/formhelpers/class-checkview-gforms-helper.php
@@ -769,13 +769,17 @@ if ( ! class_exists( 'Checkview_Gforms_Helper' ) ) {
 		/**
 		 * Returns false.
 		 *
-		 * @param int    $form_id Form's ID.
-		 * @param int    $should_check_key_field Check for filed.
-		 * @param object $form Forms object.
-		 * @param array  $entry Entry details.
+		 * Variadic on purpose: Zero Spam fires this filter with a varying
+		 * number of arguments. `gf_apply_filters()` passes 3 (value, form,
+		 * entry) because the form-id modifier is consumed by GF itself, while
+		 * two call sites use a plain `apply_filters()` that passes only 2. A
+		 * fixed 4-parameter signature therefore threw an uncaught
+		 * ArgumentCountError and 500'd the whole page render.
+		 *
+		 * @param mixed ...$args Ignored; the answer is always false.
 		 * @return bool
 		 */
-		public function checkview_disable_zero_spam_addon( $form_id, $should_check_key_field, $form, $entry ) {
+		public function checkview_disable_zero_spam_addon( ...$args ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Problem

`checkview_disable_zero_spam_addon` is registered with four **required** parameters:

```php
add_filter( 'gf_zero_spam_check_key_field', array( $this, 'checkview_disable_zero_spam_addon' ), 99, 4 );
```

Gravity Forms Zero Spam never passes four. `gf_apply_filters()` passes three (value, form, entry) because GF consumes the form-id modifier itself, and three call sites use a plain `apply_filters()` that passes only two. `WP_Hook::apply_filters` slices the args down to what is available, so PHP raises an uncaught `ArgumentCountError`:

```
Uncaught ArgumentCountError: Too few arguments to function
Checkview_Gforms_Helper::checkview_disable_zero_spam_addon(), 3 passed and exactly 4 expected
  at includes/formhelpers/class-checkview-gforms-helper.php:778
  <- gravityforms.php(7291) gf_apply_filters
  <- gravity-forms-zero-spam/includes/class-gf-zero-spam.php(327) GF_Zero_Spam->add_key_field()
  <- gform_register_init_scripts <- GFFormDisplay::get_form()
```

## Impact

Zero Spam **1.7.0** moved this filter onto the render path, inside `add_key_field()` hooked to `gform_register_init_scripts`. From that version on, an affected page containing a Gravity Form returns HTTP 500 for the duration of a CheckView test, failing the test at step 0 `goto` before a single field is filled.

Normal visitors are unaffected, since the GF helper is only loaded once the request is verified as a CheckView bot. That is why affected sites look perfectly healthy to their owners and nothing shows up in their logs at the times they check, which made this expensive to diagnose.

This code is unchanged since at least v2.2.1, so it is not a regression in any particular helper release. The trigger was the Zero Spam upgrade on the customer side.

## Fix

Make the callback variadic. It returns `false` unconditionally, so it never needed the parameters. `accepted_args` stays at 4 so we keep receiving everything the filter offers if Zero Spam ever widens it.

## Verification

Reproduced and fixed on a customer staging copy (GF 3.0.2, Zero Spam 1.10.1, helper 2.3.2, WP 7.0.3):

- Signed test-mode GET on the form page: **500 to 200**
- CheckView form test flow against that site: **failed at step 0, now passes all 8 steps**

Fatal captured via `register_shutdown_function` + `error_get_last()`, since the site's `WP_DEBUG_LOG` was on but the fatal never reached `debug.log`.

Refs FD #2890.

## Scope of impact, measured

Prod query over 45 days for tests failing at step 0 `goto` with a 500 returned 8 sites. Only two of them have Zero Spam installed at all. Live impact today is **williamslitigation.ca only**.

Two sites with the same stack do **not** crash: williamslitigationnorth.ca (GF 3.0.2 + ZS 1.10.1 + CV 2.2.1) and newpathspa.com (GF 3.0.2 + ZS 1.10.2 + CV 2.3.2), both verified as cache-miss 200 with a Gravity Form on the page. Ruled out as the differentiator: Zero Spam version (`class-gf-zero-spam.php` is byte-identical between 1.10.1 and 1.10.2) and helper version. Some per-site or per-form Zero Spam setting decides whether `add_key_field()` reaches the filter call. **Unresolved**, and worth knowing, though the fix is unconditional so correctness does not depend on it.

## Same-bug-class audit

Every fixed-arity callback in all ten form helpers was cross-checked against the real upstream arg count:

- **Clean:** Contact Form 7, WPForms, Ninja Forms, Formidable, Everest Forms, Fluent Forms, Forminator. Every declared `accepted_args` is <= what upstream emits.
- **Unaudited:** Gravity Forms' own filters, Gravity PDF `gfpdf_pdf_config`, Elementor Pro, WS Form. All paid, source not available to check.

## Follow-ups, not in this PR

- No regression test, because `development` has no test harness yet. Once the phpunit scaffolding lands, assert the callback tolerates 0/2/3/4 args.
- One Zero Spam call site (`class-gf-zero-spam-addon.php:408`) uses this filter as the `default_value` for the per-form enable toggle in the GF form editor. Our unconditional `false` would flip that default off if the helper ever ran in wp-admin. Not reachable today, since loading requires a valid request signature, but it would become reachable if `checkview_require_signed_request` were ever defaulted to false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)