### PR TITLE
feat(logs): capture PHP fatals during tests and stop serving logs publicly

### DIFF
--- a/admin/class-checkview-admin-logs.php
+++ b/admin/class-checkview-admin-logs.php
@@ -23,12 +23,33 @@
 class Checkview_Admin_Logs {
 
 	/**
+	 * Base name of the logs folder, kept as the prefix of the current one.
+	 *
+	 * @var string
+	 */
+	const LEGACY_FOLDER_NAME = 'checkview-logs';
+
+	/**
+	 * Option holding this site's random logs folder suffix.
+	 *
+	 * @var string
+	 */
+	const DIR_KEY_OPTION = 'checkview_logs_dir_key';
+
+	/**
 	 * Handles/file names for log files.
 	 *
 	 * @var array
 	 * @access private
 	 */
 	private static $_handles;
+
+	/**
+	 * Cached logs folder path, resolved once per request.
+	 *
+	 * @var string|null
+	 */
+	private static $resolved_folder = null;
 
 	/**
 	 * Constructor.
@@ -113,17 +134,120 @@ class Checkview_Admin_Logs {
 
 	/**
 	 * Gets the path of the logs folder.
-	 * 
+	 *
 	 * Returns the path of the logs folder, which, by default, is located within
 	 * the WordPress Uploads directory.
+	 *
+	 * The folder name carries a per-site random suffix. It used to be the fixed
+	 * `checkview-logs`, guessable from outside and protected only by an
+	 * `.htaccess` carrying `deny from all`. That works on Apache and LiteSpeed
+	 * but nginx ignores `.htaccess` entirely, leaving the log files publicly
+	 * readable at a predictable URL — confirmed in the field on a customer site
+	 * in August 2026. The `.htaccess` is still written as defence in depth; the
+	 * unguessable name is what protects sites where it is inert.
 	 *
 	 * @return string
 	 */
 	public static function get_logs_folder() {
 
-		$path = apply_filters( 'checkview_get_logs_folder', self::get_uploads_folder() . '/checkview-logs/' );
+		if ( null === self::$resolved_folder ) {
+			$base = trailingslashit( self::get_uploads_folder() );
+			$path = $base . self::LEGACY_FOLDER_NAME . '-' . self::get_dir_key() . '/';
 
-		return $path;
+			self::maybe_migrate_legacy_folder( $base, $path );
+
+			self::$resolved_folder = $path;
+		}
+
+		return apply_filters( 'checkview_get_logs_folder', self::$resolved_folder );
+	}
+
+	/**
+	 * Gets, creating if needed, this site's random logs folder suffix.
+	 *
+	 * @return string 16 hex characters.
+	 */
+	private static function get_dir_key() {
+
+		$key = get_option( self::DIR_KEY_OPTION, '' );
+
+		if ( is_string( $key ) && preg_match( '/^[a-f0-9]{16}$/', $key ) ) {
+			return $key;
+		}
+
+		try {
+			$key = bin2hex( random_bytes( 8 ) );
+		} catch ( Throwable $e ) {
+			// random_bytes throws when no CSPRNG is available. The name only
+			// needs to be unguessable from outside, not cryptographic.
+			$key = substr( md5( uniqid( (string) wp_rand(), true ) ), 0, 16 );
+		}
+
+		// Not autoloaded: read once per request, and only on requests that log.
+		update_option( self::DIR_KEY_OPTION, $key, false );
+
+		return $key;
+	}
+
+	/**
+	 * Moves logs out of the old, publicly guessable folder.
+	 *
+	 * @param string $base       Uploads folder, trailing slashed.
+	 * @param string $new_folder Destination folder, trailing slashed.
+	 * @return void
+	 */
+	private static function maybe_migrate_legacy_folder( $base, $new_folder ) {
+
+		$legacy = $base . self::LEGACY_FOLDER_NAME . '/';
+
+		if ( $legacy === $new_folder || ! is_dir( $legacy ) ) {
+			return;
+		}
+
+		if ( ! is_dir( $new_folder )
+			&& @rename( untrailingslashit( $legacy ), untrailingslashit( $new_folder ) ) ) {
+
+			self::repoint_stored_log_path( $legacy, $new_folder );
+
+			return;
+		}
+
+		// Either the destination already exists or the rename was refused
+		// (restrictive permissions, open handles, cross-device). Leaving the
+		// old folder in place would defeat the purpose, since that is the path
+		// being served publicly. These are our own logs, pruned after 7 days,
+		// so nothing depends on them.
+		foreach ( array( '*.log', '.htaccess', 'index.html' ) as $pattern ) {
+			foreach ( (array) glob( $legacy . $pattern ) as $file ) {
+				@unlink( $file );
+			}
+		}
+
+		@rmdir( untrailingslashit( $legacy ) );
+	}
+
+	/**
+	 * Rewrites the admin log viewer's saved file path after a migration.
+	 *
+	 * @param string $legacy     Old folder, trailing slashed.
+	 * @param string $new_folder New folder, trailing slashed.
+	 * @return void
+	 */
+	private static function repoint_stored_log_path( $legacy, $new_folder ) {
+
+		$options = get_option( 'checkview_log_options', array() );
+
+		if ( empty( $options['checkview_log_select'] ) || ! is_string( $options['checkview_log_select'] ) ) {
+			return;
+		}
+
+		if ( 0 !== strpos( $options['checkview_log_select'], $legacy ) ) {
+			return;
+		}
+
+		$options['checkview_log_select'] = $new_folder . substr( $options['checkview_log_select'], strlen( $legacy ) );
+
+		update_option( 'checkview_log_options', $options );
 	}
 
 	/**

--- a/checkview.php
+++ b/checkview.php
@@ -72,6 +72,12 @@ if ( ! defined( 'CHECKVIEW_URI' ) ) {
 	define( 'CHECKVIEW_URI', trailingslashit( plugin_dir_url( __FILE__ ) ) );
 }
 
+// Registered here rather than on a hook so a fatal raised during another
+// plugin's `init` is still recorded. Nothing is written unless the request
+// later verifies as a CheckView test.
+require_once CHECKVIEW_INC_DIR . 'class-checkview-fatal-capture.php';
+Checkview_Fatal_Capture::init();
+
 /**
  * Invalidate OPcache recursively.
  *

--- a/includes/class-checkview-fatal-capture.php
+++ b/includes/class-checkview-fatal-capture.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Checkview_Fatal_Capture class
+ *
+ * @since 2.3.3
+ *
+ * @package Checkview
+ * @subpackage Checkview/includes
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+	die( 'Direct access not Allowed.' );
+}
+
+if ( ! class_exists( 'Checkview_Fatal_Capture' ) ) {
+	/**
+	 * Records PHP fatal errors that occur during a CheckView test.
+	 *
+	 * A fatal on a form page turns a test into an opaque "HTTP 500" with no
+	 * further detail, and chasing the underlying error has meant asking the
+	 * customer for server logs. That round trip routinely fails: hosts write
+	 * PHP errors somewhere the customer cannot reach, security plugins block
+	 * the log file, and even with `WP_DEBUG_LOG` enabled the fatal does not
+	 * always land in `debug.log`.
+	 *
+	 * This captures the error ourselves via `error_get_last()` on shutdown and
+	 * writes it to the plugin's own log, which the SaaS already reads over the
+	 * signed `/checkview/v1/get-logs` endpoint. `error_get_last()` is populated
+	 * by PHP regardless of `error_reporting`, `display_errors` or `log_errors`,
+	 * so this works on sites with debugging switched entirely off. WordPress
+	 * core relies on the same mechanism to render its "critical error" page.
+	 *
+	 * Scope: nothing is recorded for ordinary visitors. See `capture()` for the
+	 * gate.
+	 *
+	 * Known blind spots, in rough order of likelihood:
+	 * - A fatal raised before this plugin file loads (an earlier plugin in the
+	 *   load order, an mu-plugin, or wp-config).
+	 * - Out-of-memory, unless the reserve below is large enough to unwind.
+	 * - Segfaults and killed workers, where no shutdown function runs at all.
+	 * - 500s produced by the web server, a WAF or a proxy rather than by PHP.
+	 *
+	 * @package Checkview
+	 * @subpackage Checkview/includes
+	 * @author Check View <support@checkview.io>
+	 */
+	class Checkview_Fatal_Capture {
+
+		/**
+		 * Log channel these errors are written to.
+		 *
+		 * Named so it lands in the same folder as `ip-logs`/`api-logs` and is
+		 * picked up by the existing get-logs endpoint and its 7 day pruning.
+		 *
+		 * @var string
+		 */
+		const LOG_HANDLE = 'fatal-logs';
+
+		/**
+		 * Longest error message recorded, in bytes.
+		 *
+		 * An uncaught Error's message carries its whole stack trace, which is
+		 * the useful part, but a deep trace can run to hundreds of kilobytes.
+		 *
+		 * @var int
+		 */
+		const MAX_MESSAGE_LENGTH = 8192;
+
+		/**
+		 * Memory freed at shutdown so an out-of-memory fatal has room to log.
+		 *
+		 * @var string|null
+		 */
+		private static $reserve = null;
+
+		/**
+		 * Registers the shutdown handler for likely CheckView requests.
+		 *
+		 * Called as early as the plugin loads rather than on a hook, so a fatal
+		 * during another plugin's `init` is still caught.
+		 *
+		 * @return void
+		 */
+		public static function init() {
+			if ( ! self::is_probable_test_request() ) {
+				return;
+			}
+
+			// Freed first thing in capture(), so an "Allowed memory size
+			// exhausted" fatal still has headroom to format and write itself.
+			self::$reserve = str_repeat( ' ', 512 * 1024 );
+
+			register_shutdown_function( array( __CLASS__, 'capture' ) );
+		}
+
+		/**
+		 * Writes the last error to the log if it was fatal.
+		 *
+		 * @return void
+		 */
+		public static function capture() {
+			self::$reserve = null;
+
+			// The real gate. CV_TEST_ID is defined by
+			// checkview_init_current_test(), which only runs once
+			// Checkview::is_bot() has verified the request signature, so a
+			// visitor appending ?checkview_test_id=... to a URL can never
+			// reach a write. Deliberately not re-running the signature check
+			// here: checkview_validate_jwt_token() logs on every failure path,
+			// which would hand anyone an unauthenticated way to grow a
+			// customer's log files.
+			if ( ! defined( 'CV_TEST_ID' ) ) {
+				return;
+			}
+
+			$error = error_get_last();
+
+			if ( ! self::is_fatal( $error ) ) {
+				return;
+			}
+
+			// Logger lives in admin/, which is loaded by the main plugin class.
+			// If we fataled before that, there is nowhere to write.
+			if ( ! class_exists( 'Checkview_Admin_Logs' ) ) {
+				return;
+			}
+
+			$message = isset( $error['message'] ) ? (string) $error['message'] : 'unknown error';
+
+			if ( strlen( $message ) > self::MAX_MESSAGE_LENGTH ) {
+				$message = substr( $message, 0, self::MAX_MESSAGE_LENGTH ) . ' [truncated]';
+			}
+
+			// We are already inside a shutdown handler after a fatal. If the
+			// write itself fails (the logger reaches for an option, and the
+			// original fatal may have been a dead database connection), let it
+			// go quietly rather than raise a second error nobody will see.
+			try {
+				Checkview_Admin_Logs::add(
+					self::LOG_HANDLE,
+					sprintf(
+						'FATAL during test [%s] on [%s]: %s in %s:%d',
+						CV_TEST_ID,
+						self::current_url(),
+						$message,
+						isset( $error['file'] ) ? $error['file'] : 'unknown file',
+						isset( $error['line'] ) ? (int) $error['line'] : 0
+					)
+				);
+			} catch ( Throwable $e ) {
+				return;
+			}
+		}
+
+		/**
+		 * Whether an error entry represents a fatal error.
+		 *
+		 * @param array|null $error Value returned by error_get_last().
+		 * @return bool
+		 */
+		private static function is_fatal( $error ) {
+			if ( ! is_array( $error ) || ! isset( $error['type'] ) ) {
+				return false;
+			}
+
+			$fatal_types = array(
+				E_ERROR,
+				E_PARSE,
+				E_CORE_ERROR,
+				E_COMPILE_ERROR,
+				E_USER_ERROR,
+				E_RECOVERABLE_ERROR,
+			);
+
+			return in_array( (int) $error['type'], $fatal_types, true );
+		}
+
+		/**
+		 * Cheap guess at whether this request belongs to a CheckView test.
+		 *
+		 * Only decides whether to register the shutdown handler, so a false
+		 * positive costs one no-op function call and a false negative only
+		 * loses a log line. The authoritative check is CV_TEST_ID in
+		 * capture(). Covers all four ways our traffic identifies itself: the
+		 * navigation query string, a form POST whose referer carries it, the
+		 * plugin's own cookie across redirects, and the signed header.
+		 *
+		 * @return bool
+		 */
+		private static function is_probable_test_request() {
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended
+			if ( ! empty( $_REQUEST['checkview_test_id'] ) ) {
+				return true;
+			}
+			// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+			if ( ! empty( $_COOKIE['checkview_test_type'] ) ) {
+				return true;
+			}
+
+			if ( ! empty( $_SERVER['HTTP_X_CHECKVIEW_SIGNATURE'] ) ) {
+				return true;
+			}
+
+			if ( ! empty( $_SERVER['HTTP_REFERER'] )
+				&& false !== strpos( (string) $_SERVER['HTTP_REFERER'], 'checkview_test_id=' ) ) {
+				return true;
+			}
+
+			return false;
+		}
+
+		/**
+		 * Best-effort URL of the current request, for the log line.
+		 *
+		 * Built from superglobals rather than WordPress helpers because this
+		 * runs at shutdown, where a fatal may have left core half-loaded.
+		 *
+		 * @return string
+		 */
+		private static function current_url() {
+			$host = isset( $_SERVER['HTTP_HOST'] ) ? (string) $_SERVER['HTTP_HOST'] : '';
+			$uri  = isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '';
+
+			if ( '' === $host && '' === $uri ) {
+				return 'unknown url';
+			}
+
+			return substr( $host . $uri, 0, 500 );
+		}
+	}
+}


### PR DESCRIPTION
Two related changes. The first is the capability we actually want; the second is the precondition for shipping it safely.

## 1. Capture PHP fatals during CheckView tests

A fatal on a form page turns a test into an opaque `HTTP 500` at step 0 with nothing to act on. Recovering the real error has meant asking the customer for server logs, and that round trip keeps failing:

- hosts write PHP errors somewhere the customer cannot reach
- security plugins block the log file over HTTP
- on FD #2890 the fatal **never reached `debug.log` even though `WP_DEBUG_LOG` was `true`**

That ticket took a week and a staging handoff to read a single stack trace.

`Checkview_Fatal_Capture` registers a shutdown handler and records `error_get_last()` to a new `fatal-logs` channel. The SaaS already reads that folder over the signed `/checkview/v1/get-logs` endpoint, so support gets the file and line with **no customer involvement and no server access**.

This works with debugging switched entirely off. `error_get_last()` is populated by PHP regardless of `error_reporting`, `display_errors` or `log_errors` — it is the same mechanism core uses to render its critical-error page.

### Scope and safety

Nothing is recorded for ordinary visitors.

- **Registration** is gated on a cheap request-shape check (query param, plugin cookie, signed header, or a referer carrying the test id). Covers the initial navigation, the form POST, and redirect hops.
- **The write** is gated on `CV_TEST_ID`, which is only defined once `Checkview::is_bot()` has verified the request signature. Appending `?checkview_test_id=` to a URL can never reach a write.
- The signature is deliberately **not** re-checked at shutdown: `checkview_validate_jwt_token()` logs on every failure path, which would hand anyone an unauthenticated way to grow a customer's log files.
- Registered from the main plugin file rather than a hook, so a fatal during another plugin's `init` is still caught.
- Messages are capped at 8 KB, and the write is wrapped so a secondary failure cannot cascade.

Blind spots are documented on the class: fatals raised before this plugin loads, segfaults and killed workers, and 500s produced by the web server or a WAF rather than PHP.

## 2. Stop serving the log folder publicly

This change puts stack traces into those logs, so the storage needed fixing first.

The folder was the fixed, guessable `wp-content/uploads/checkview-logs/`, protected only by an `.htaccess` containing `deny from all`. That holds on Apache and LiteSpeed. **nginx ignores `.htaccess` entirely.**

Surveying nine customer sites: LiteSpeed, Apache and Prometheus hosts correctly returned 403, and one nginx host **served its CheckView log file publicly at HTTP 200, 9 KB**. That exposure exists today, before this PR.

The folder now carries a per-site random suffix (`checkview-logs-<16 hex>`), stored in a non-autoloaded option. The `.htaccess` and `index.html` are still written as defence in depth; the unguessable name is what protects sites where `.htaccess` is inert. Existing folders are renamed on first use, and if the rename is refused the old files are deleted rather than left served. The admin log viewer's stored path is repointed.

**No SaaS-side change needed:** `get-logs` globs `Checkview_Admin_Logs::get_logs_folder()`, so it follows the folder automatically. The `checkview_get_logs_folder` filter still wins for anyone overriding it.

## Verification

Standalone harnesses, run under `error_reporting=0`, `display_errors=0`, `log_errors=0`:

| Case | Result |
|---|---|
| Fatal on a verified test | 1 entry, with message, file, line and full stack trace |
| Fatal on an unverified request | 0 entries |
| Non-fatal warning | 0 entries |
| Clean request | 0 entries |
| Out of memory | 1 entry, via the released reserve |
| Logger throws | no cascade |
| Folder: fresh site | random suffix, stable within a request, key persisted |
| Folder: legacy migration | renamed, contents intact, stored admin path repointed |
| Folder: destination collision | exposed legacy files removed, directory removed |
| Folder: `checkview_get_logs_folder` filter | still wins |

The shutdown-handler approach was also proven end to end on a real WordPress site during the FD #2890 investigation: an equivalent handler installed on a customer staging copy captured the fatal that `debug.log` had missed, which is how that root cause was finally found. Worth noting that WordPress registers its own fatal handler before plugins, and ours still ran, because core's handler calls `wp_die()` with `exit => false`.

## Follow-up, not in this PR

Have the runner fetch `get-logs` automatically when a step fails with a 5xx and attach the fatal to the test result, so it appears in the dashboard next to the failed step. The runner already signs these tokens, so it is plumbing rather than new capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)